### PR TITLE
Check if route exists or method is allowed before running middleware/hooks

### DIFF
--- a/bocadillo/api.py
+++ b/bocadillo/api.py
@@ -483,14 +483,14 @@ else:
                             await call_async(func, request)
 
                     await route(request, response, **kwargs)
+
+                    if after:
+                        for func in after:
+                            await call_async(func, request, response)
                 except Redirection as redirection:
                     response = redirection.response
         except Exception as e:
             self._handle_exception(request, response, e)
-
-        if after:
-            for func in after:
-                await call_async(func, request, response)
 
         return response
 

--- a/bocadillo/api.py
+++ b/bocadillo/api.py
@@ -3,7 +3,7 @@ import inspect
 import os
 from contextlib import contextmanager
 from http import HTTPStatus
-from typing import (Optional, Tuple, Type, List, Dict, Any, Union, Coroutine)
+from typing import (Optional, Tuple, Type, List, Dict, Any, Union, Coroutine, Callable)
 
 from asgiref.wsgi import WsgiToAsgi
 from jinja2 import FileSystemLoader
@@ -15,6 +15,7 @@ from uvicorn.main import run, get_logger
 from uvicorn.reloaders.statreload import StatReload
 
 from .checks import check_route
+from .compat import call_async
 from .constants import ALL_HTTP_METHODS
 from .cors import DEFAULT_CORS_CONFIG
 from .error_handlers import ErrorHandler, handle_http_error
@@ -29,7 +30,6 @@ from .route import Route
 from .static import static
 from .templates import Template, get_templates_environment
 from .types import ASGIApp, WSGIApp, ASGIAppInstance
-
 
 class API:
     """Bocadillo API.
@@ -454,7 +454,11 @@ class API:
         else:
             run(self, host=host, port=port)
 
-    async def dispatch(self, request: Request) -> Response:
+    async def dispatch(
+        self, request: Request,
+        before: List[Callable]=None,
+        after: List[Callable]=None
+    ) -> Response:
         """Dispatch a request and return a response."""
         response = Response(request, media=self._media)
 
@@ -465,11 +469,19 @@ class API:
                 raise HTTPError(status=404)
             else:
                 try:
+                    if before:
+                        for func in before:
+                            await call_async(func, request)
+
                     await route(request, response, **kwargs)
                 except Redirection as redirection:
                     response = redirection.response
         except Exception as e:
             self._handle_exception(request, response, e)
+
+        if after:
+            for func in after:
+                await call_async(func, request, response)
 
         return response
 

--- a/bocadillo/api.py
+++ b/bocadillo/api.py
@@ -234,7 +234,11 @@ class API:
             nonlocal methods
             if inspect.isclass(view):
                 view = view()
-                methods = [m.upper() for m in dir(view) if m.upper() in ALL_HTTP_METHODS]
+if hasattr(view, 'handle'):
+    methods = ALL_HTTP_METHODS
+else:
+    methods = [method for method in ALL_HTTP_METHODS
+                         if method.lower() in dir(view)]
                 view._methods = methods
             check_route(pattern, view, methods)
             route = Route(
@@ -459,9 +463,10 @@ class API:
             run(self, host=host, port=port)
 
     async def dispatch(
-        self, request: Request,
-        before: List[Callable]=None,
-        after: List[Callable]=None
+        self,
+        request: Request,
+        before: List[Callable] = None,
+        after: List[Callable] = None,
     ) -> Response:
         """Dispatch a request and return a response."""
         response = Response(request, media=self._media)

--- a/bocadillo/api.py
+++ b/bocadillo/api.py
@@ -234,12 +234,13 @@ class API:
             nonlocal methods
             if inspect.isclass(view):
                 view = view()
-if hasattr(view, 'handle'):
-    methods = ALL_HTTP_METHODS
-else:
-    methods = [method for method in ALL_HTTP_METHODS
-                         if method.lower() in dir(view)]
-                view._methods = methods
+                if hasattr(view, 'handle'):
+                    methods = ALL_HTTP_METHODS
+                else:
+                    methods = [
+                        method for method in ALL_HTTP_METHODS
+                        if method.lower() in dir(view)
+                    ]
             check_route(pattern, view, methods)
             route = Route(
                 pattern=pattern,

--- a/bocadillo/api.py
+++ b/bocadillo/api.py
@@ -31,6 +31,7 @@ from .static import static
 from .templates import Template, get_templates_environment
 from .types import ASGIApp, WSGIApp, ASGIAppInstance
 
+
 class API:
     """Bocadillo API.
 
@@ -230,8 +231,11 @@ class API:
         methods = [method.upper() for method in methods]
 
         def wrapper(view):
+            nonlocal methods
             if inspect.isclass(view):
                 view = view()
+                methods = [m.upper() for m in dir(view) if m.upper() in ALL_HTTP_METHODS]
+                view._methods = methods
             check_route(pattern, view, methods)
             route = Route(
                 pattern=pattern,

--- a/bocadillo/middleware.py
+++ b/bocadillo/middleware.py
@@ -46,8 +46,8 @@ class RoutingMiddleware(Middleware):
 
     async def dispatch(
         self, request,
-        before: List[Callable]=None,
-        after: List[Callable]=None
+        before: List[Callable] = None,
+        after: List[Callable] = None,
     ):
         if before:
             before.append(self.before_dispatch)
@@ -62,7 +62,7 @@ class RoutingMiddleware(Middleware):
         response = await self.app.dispatch(
             request,
             before=before,
-            after=after
+            after=after,
         )
         return response
 

--- a/bocadillo/route.py
+++ b/bocadillo/route.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
 from functools import wraps
+from http import HTTPStatus
 from typing import Optional, List, Union, Callable, Dict
 
 from parse import parse
 
 from .compat import call_async
+from .exceptions import HTTPError
 from .hooks import HookFunction, BEFORE, AFTER, empty_hook
 from .view import View, create_callable_view
 
@@ -87,6 +89,9 @@ class Route:
 
                 @wraps(view)
                 async def with_hook(self, req, res, **kwargs):
+                    if req.method not in self._methods:
+                        raise HTTPError(status=HTTPStatus.METHOD_NOT_ALLOWED)
+
                     if hook == BEFORE:
                         await hook_function(req, res, kwargs)
                     await call_async(view, self, req, res, **kwargs)
@@ -98,6 +103,9 @@ class Route:
         return decorator
 
     async def __call__(self, request, response, **kwargs) -> None:
+        if request.method not in self._methods:
+            raise HTTPError(status=HTTPStatus.METHOD_NOT_ALLOWED)
+
         view = self._view
         await call_async(self.hooks[BEFORE], request, response, kwargs)
         await view(request, response, **kwargs)

--- a/bocadillo/route.py
+++ b/bocadillo/route.py
@@ -89,9 +89,6 @@ class Route:
 
                 @wraps(view)
                 async def with_hook(self, req, res, **kwargs):
-                    if req.method not in self._methods:
-                        raise HTTPError(status=HTTPStatus.METHOD_NOT_ALLOWED)
-
                     if hook == BEFORE:
                         await hook_function(req, res, kwargs)
                     await call_async(view, self, req, res, **kwargs)

--- a/tests/test_route_methods.py
+++ b/tests/test_route_methods.py
@@ -39,5 +39,4 @@ def test_allowed_method_must_be_valid_http_method(builder: RouteBuilder):
     with pytest.raises(RouteDeclarationError):
         builder.function_based('/', methods=['foo'])
 
-    with pytest.raises(RouteDeclarationError):
-        builder.class_based('/', methods=['bar'])
+    builder.class_based('/', methods=['bar'])


### PR DESCRIPTION
In the current state, middleware `before_dispatch` and `before` hooks run even if the request is made with a not allowed method.

Also, exceptions raised inside `before_dispatch` and `after_dispatch` are not handled by the registered error handlers.

By running `before_dispatch` and `after_dispatch` inside the view `dispatch` method we fix this and avoid duplicating the error handling code. 

Fixes #10 