### PR TITLE
Do not support unsafe methods by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bocadillo adheres to [Semantic Versioning](https://semver.org).
 - Exceptions raised in `before_dispatch()` and `after_dispatch()` middleware callbacks will now *always* lead to 500 error responses — they won't be handled by error handlers anymore, because these are registered on the `API` which middleware only wrap around. The only exception to this is, of course, `HTTPError`.
 - All routes now have an inferred `name` based on their function or class name. Explicit route naming is still possible.
 - Because of the above, names of routes in recipes now use the recipe's name as a namespace, i.e. `recipe_name:route_name` instead of `route_name`.
+- Unsafe HTTP verbs used to be supported by defaults on function-based routes. Only the safe ones, GET and HEAD, are supported by default now.
 
 ### Deprecated
 

--- a/bocadillo/routing/router.py
+++ b/bocadillo/routing/router.py
@@ -45,7 +45,7 @@ class Router:
     ):
         """Build and register a route."""
         if methods is None:
-            methods = ALL_HTTP_METHODS
+            methods = ['get', 'head']
 
         methods = [method.upper() for method in methods]
 

--- a/docs/topics/request-handling/routes-url-design.md
+++ b/docs/topics/request-handling/routes-url-design.md
@@ -133,7 +133,7 @@ Referencing a non-existing named route with `url_for()` will trigger an `HTTPErr
 
 ## Specifying HTTP methods
 
-By default, a route exposes the following HTTP methods: GET, HEAD, POST, PUT, DELETE, OPTIONS, PATCH.
+By default, a route only exposes the safe HTTP methods, i.e. `GET` and `HEAD`.
 
 On function-based views,
 you can use the `methods` argument to `@api.route()` to specify the set of

--- a/tests/test_route_methods.py
+++ b/tests/test_route_methods.py
@@ -17,6 +17,18 @@ def test_allowed_methods(builder: RouteBuilder, methods, method, status):
 
 
 @pytest.mark.parametrize(
+    'method', ['post', 'delete', 'put', 'patch', 'options']
+)
+def test_unsafe_methods_not_supported_by_default(api: API, method):
+    @api.route('/')
+    async def index(req, res):
+        pass
+
+    response = getattr(api.client, method)('/')
+    assert response.status_code == 405
+
+
+@pytest.mark.parametrize(
     'methods, method',
     [(['get', 'post'], 'get'), (['post'], 'get'), ([], 'put')],
 )


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #37 

## Proposed changes

- Only support `GET` and `HEAD` by default.
- Update docs and CHANGELOG.
