### PR TITLE
Add version commands and flags to boca

### DIFF
--- a/bocadillo/__main__.py
+++ b/bocadillo/__main__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/bocadillo/__main__.py
+++ b/bocadillo/__main__.py
@@ -1,4 +1,6 @@
-from .cli import cli
+from .cli import create_cli
+
+cli = create_cli()
 
 if __name__ == "__main__":
     cli()

--- a/bocadillo/cli.py
+++ b/bocadillo/cli.py
@@ -1,15 +1,22 @@
 """Bocadillo CLI factory."""
 import os
-from inspect import cleandoc
+from inspect import getsource
+
+import click
 
 from . import __version__
-from .ext import click
 
 CUSTOM_COMMANDS_FILE_ENV_VAR = "BOCA_CUSTOM_COMMANDS_FILE"
 
 
 def get_custom_commands_path() -> str:
     return os.getenv(CUSTOM_COMMANDS_FILE_ENV_VAR, "boca.py")
+
+
+def get_custom_commands_script_contents() -> str:
+    from .scaffold import boca
+
+    return getsource(boca)
 
 
 class BocaCLI(click.Group):
@@ -81,28 +88,10 @@ def create_cli() -> click.Command:
     )
     def init_custom(directory: str):
         """Generate files required to build custom commands."""
-        custom_commands_script_contents = (
-            cleandoc(
-                '''"""Custom Bocadillo commands.
-        
-                Use Click to build custom commands. For documentation, see:
-                https://click.palletsprojects.com
-                """
-                from bocadillo.ext import click
-        
-        
-                @click.group()
-                def cli():
-                    pass
-        
-                # Write your @cli.command() functions below.\n
-                '''
-            )
-            + "\n"
-        )
+        contents = get_custom_commands_script_contents()
         path = os.path.join(directory, get_custom_commands_path())
         with open(path, "w") as f:
-            f.write(custom_commands_script_contents)
+            f.write(contents)
         click.echo(click.style(f"Generated {path}", fg="green"))
         click.echo("Open the file and start building!")
 

--- a/bocadillo/cli.py
+++ b/bocadillo/cli.py
@@ -8,7 +8,7 @@ from .ext import click
 CUSTOM_COMMANDS_FILE_ENV_VAR = "BOCA_CUSTOM_COMMANDS_FILE"
 
 
-def get_custom_commands_file_path():
+def get_custom_commands_path() -> str:
     return os.getenv(CUSTOM_COMMANDS_FILE_ENV_VAR, "boca.py")
 
 
@@ -31,7 +31,7 @@ class BocaCLI(click.Group):
         super().__init__(*args, **kwargs)
         self._load_group(path)
 
-    def _load_group(self, path):
+    def _load_group(self, path: str):
         ns = {}
 
         try:
@@ -62,7 +62,7 @@ def create_cli() -> click.Command:
     }
     version_flags = ("-v", "-V", "--version")
 
-    @click.group(cls=BocaCLI, path=get_custom_commands_file_path())
+    @click.group(cls=BocaCLI, path=get_custom_commands_path())
     @click.version_option(__version__, *version_flags, **version_kwargs)
     def cli():
         pass
@@ -100,7 +100,7 @@ def create_cli() -> click.Command:
             )
             + "\n"
         )
-        path = os.path.join(directory, get_custom_commands_file_path())
+        path = os.path.join(directory, get_custom_commands_path())
         with open(path, "w") as f:
             f.write(custom_commands_script_contents)
         click.echo(click.style(f"Generated {path}", fg="green"))

--- a/bocadillo/cli.py
+++ b/bocadillo/cli.py
@@ -107,7 +107,3 @@ def create_cli() -> click.Command:
         click.echo("Open the file and start building!")
 
     return cli
-
-
-# Exposed to the setup.py entry point
-cli = create_cli()

--- a/bocadillo/cli.py
+++ b/bocadillo/cli.py
@@ -1,8 +1,8 @@
 """Bocadillo CLI factory."""
 import os
 from inspect import cleandoc
-from typing import List
 
+from . import __version__
 from .ext import click
 
 CUSTOM_COMMANDS_FILE_ENV_VAR = "BOCA_CUSTOM_COMMANDS_FILE"
@@ -12,12 +12,12 @@ def get_custom_commands_file_path():
     return os.getenv(CUSTOM_COMMANDS_FILE_ENV_VAR, "boca.py")
 
 
-class FileGroupCLI(click.MultiCommand):
+class BocaCLI(click.Group):
     """Multi-command CLI that loads a group of commands from a file.
 
     Notes
     -----
-    - Commands are loaded from a file determined by `file_name`, relative to the
+    - Commands are loaded from a file determined by `path`, relative to the
     current working directory (i.e., when the CLI script is executed).
     - The first click.Group object found in that file is used as a source of
     commands.
@@ -27,59 +27,55 @@ class FileGroupCLI(click.MultiCommand):
     https://click.palletsprojects.com/en/7.x/commands/#custom-multi-commands
     """
 
-    def __init__(self, file_name: str, *args, **kwargs):
+    def __init__(self, path: str, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._group: click.Group = None
-        self.file_name = file_name
+        self._load_group(path)
 
-    def _load_group(self):
+    def _load_group(self, path):
         ns = {}
-        path = self.file_name
 
         try:
             with open(path, "r") as f:
                 code = compile(source=f.read(), filename=path, mode="exec")
-                eval(code, ns, ns)
         except FileNotFoundError:
-            # User did not create custom commands, use an empty group.
-            self._group = click.Group()
+            # User did not create custom commands
             return
-
-        for key, value in ns.items():
-            if isinstance(value, click.Group):
-                self._group = value
-                break
         else:
+            eval(code, ns, ns)
+
+        groups = (val for val in ns.values() if isinstance(val, click.Group))
+        group = next(groups, None)
+        if group is None:
             raise click.ClickException(
                 f"Expected at least one group in {path}, none found."
             )
-
-    @property
-    def group(self) -> click.Group:
-        """Lazy-loaded, cached group object."""
-        if self._group is None:
-            self._load_group()
-        return self._group
-
-    def list_commands(self, ctx: click.Context) -> List[str]:
-        return self.group.list_commands(ctx)
-
-    def get_command(self, ctx: click.Context, name: str) -> click.Command:
-        return self.group.get_command(ctx, name)
+        for name, cmd in group.commands.items():
+            self.add_command(cmd, name)
 
 
 def create_cli() -> click.Command:
-    @click.group()
-    def builtin():
+    """Create a Bocadillo CLI instance."""
+
+    version_kwargs = {
+        "prog_name": "Bocadillo",
+        "message": "%(prog)s v%(version)s",
+    }
+    version_flags = ("-v", "-V", "--version")
+
+    @click.group(cls=BocaCLI, path=get_custom_commands_file_path())
+    @click.version_option(__version__, *version_flags, **version_kwargs)
+    def cli():
         pass
 
-    @builtin.command(name="help")
-    @click.pass_context
-    def help_(ctx):
-        """Show help about boca."""
-        click.echo(ctx.parent.get_help())
+    @cli.command()
+    def version():
+        """Show the version and exit."""
+        click.echo(
+            version_kwargs["message"]
+            % {"prog": version_kwargs["prog_name"], "version": __version__}
+        )
 
-    @builtin.command(name="init:custom")
+    @cli.command(name="init:custom")
     @click.option(
         "-d", "--directory", default="", help="Where files should be generated."
     )
@@ -88,19 +84,19 @@ def create_cli() -> click.Command:
         custom_commands_script_contents = (
             cleandoc(
                 '''"""Custom Bocadillo commands.
-    
-            Use Click to build custom commands. For documentation, see:
-            https://click.palletsprojects.com
-            """
-            from bocadillo.ext import click
-    
-    
-            @click.group()
-            def cli():
-                pass
-    
-            # Write your @cli.command() functions below.\n
-            '''
+        
+                Use Click to build custom commands. For documentation, see:
+                https://click.palletsprojects.com
+                """
+                from bocadillo.ext import click
+        
+        
+                @click.group()
+                def cli():
+                    pass
+        
+                # Write your @cli.command() functions below.\n
+                '''
             )
             + "\n"
         )
@@ -110,10 +106,7 @@ def create_cli() -> click.Command:
         click.echo(click.style(f"Generated {path}", fg="green"))
         click.echo("Open the file and start building!")
 
-    custom = FileGroupCLI(file_name=get_custom_commands_file_path())
-
-    # Builtins first to prevent override in custom commands.
-    return click.CommandCollection(sources=[builtin, custom])
+    return cli
 
 
 # Exposed to the setup.py entry point

--- a/bocadillo/ext/__init__.py
+++ b/bocadillo/ext/__init__.py
@@ -1,2 +1,0 @@
-# Alias
-import click

--- a/bocadillo/scaffold/boca.py
+++ b/bocadillo/scaffold/boca.py
@@ -1,0 +1,14 @@
+"""Custom Bocadillo commands.
+
+Use Click to build custom commands. For documentation, see:
+https://click.palletsprojects.com
+"""
+import click
+
+
+@click.group()
+def cli():
+    pass
+
+
+# Write your @cli.command() functions below.

--- a/docs/topics/tooling/cli.md
+++ b/docs/topics/tooling/cli.md
@@ -8,11 +8,12 @@ Bocadillo comes with `boca`, a handy CLI built with [Click] for performing commo
 Usage: boca [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  --help  Show this message and exit.
+  -v, -V, --version  Show the version and exit.
+  --help             Show this message and exit.
 
 Commands:
-  help         Show help about boca.
   init:custom  Generate files required to build custom commands.
+  version      Show the version and exit.
 ```
 
 ## Extending `boca`

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=["bocadillo", "bocadillo.ext", "bocadillo.routing"],
+    packages=["bocadillo", "bocadillo.routing", "bocadillo.scaffold"],
     install_requires=[
         "starlette",
         "uvicorn",

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
     ],
-    entry_points={"console_scripts": ["boca=bocadillo.cli:cli"]},
+    entry_points={"console_scripts": ["boca=bocadillo.__main__:cli"]},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple
 
 import pytest
+from click.testing import CliRunner
 
 from bocadillo import API
 from .utils import RouteBuilder
@@ -44,3 +45,8 @@ def template_file(api: API, tmpdir_factory):
 @pytest.fixture
 def template_file_elsewhere(api: API, tmpdir_factory):
     return _create_template(api, tmpdir_factory, dirname="templates_elsewhere")
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,19 @@
 from subprocess import call
 
+import pytest
+
+from bocadillo import __version__
+from bocadillo.cli import create_cli
+
 
 def test_can_call_boca():
     assert call(["boca"]) == 0
+
+
+@pytest.mark.parametrize("flag", ["-v", "-V", "--version", "version"])
+def test_get_version(runner, flag):
+    cli = create_cli()
+
+    result = runner.invoke(cli, [flag])
+    assert result.exit_code == 0
+    assert __version__ in result.output

--- a/tests/test_cli_custom_commands.py
+++ b/tests/test_cli_custom_commands.py
@@ -21,7 +21,7 @@ def test_can_provide_custom_commands(runner, tmpdir):
     boca_dot_py.write(
         cleandoc(
             """
-    from bocadillo.ext import click
+    import click
 
     @click.group()
     def cli():

--- a/tests/test_cli_custom_commands.py
+++ b/tests/test_cli_custom_commands.py
@@ -1,15 +1,7 @@
 import os
 from inspect import cleandoc
 
-import pytest
-from click.testing import CliRunner
-
 from bocadillo.cli import create_cli
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 def test_can_init_custom_commands(runner, tmpdir):


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #52 

## Proposed changes

- Refactor BocaCLI plugin system
- Allow to display version through `-v`, `-V`, `--version` or `version`
