### PR TITLE
Silence "No directory at {static_dir}" warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Bocadillo adheres to [Semantic Versioning](https://semver.org).
 
 - Show Bocadillo version using `boca -v/-V/--version/version`.
 
+### Fixed
+
+- Serving static files from a non-existing directory (including the default one) used to raise an invasive warning. It has been silenced.
+
 ## [v0.7.0]
 
 ### Added

--- a/bocadillo/static.py
+++ b/bocadillo/static.py
@@ -1,3 +1,5 @@
+from os.path import exists
+
 from whitenoise import WhiteNoise
 
 from .types import WSGIApp
@@ -10,5 +12,6 @@ def static(directory: str) -> WSGIApp:
     Powered by WhiteNoise.
     """
     app = WhiteNoise(empty_wsgi_app())
-    app.add_files(directory)
+    if exists(directory):
+        app.add_files(directory)
     return app

--- a/docs/topics/features/static-files.md
+++ b/docs/topics/features/static-files.md
@@ -47,6 +47,11 @@ To modify the root URL path, use `static_root`:
 api = bocadillo.API(static_root='assets')
 ```
 
+::: tip
+If the `static_dir` does not exist, Bocadillo won't attempt to serve assets from
+it, and no errors nor warnings will be raised.
+:::
+
 ## Extra static files directories
 
 You can serve other static directories using `app.mount()` and the

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bocadillo import API, static
 
 FILE_DIR = "js"
@@ -57,3 +59,9 @@ def test_mount_extra_static_files_dirs(tmpdir_factory):
     response = api.client.get(f"/assets/{FILE_DIR}/{FILE_NAME}")
     assert response.status_code == 200
     assert response.text == FILE_CONTENTS
+
+
+def test_if_static_dir_does_not_exist_then_no_files_mounted():
+    with pytest.warns(None) as record:
+        API(static_dir="foo")
+    assert len(record) == 0


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #7 

## Proposed changes

- Do not attempt to serve static files from non-existing locations.
- Update docs and CHANGELOG.
