### PR TITLE
Allow to specify detail on HTTPError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bocadillo adheres to [Semantic Versioning](https://semver.org).
 
 - Show Bocadillo version using `boca -v/-V/--version/version`.
 - Built-in `HTTPError` handlers: `error_to_html`, `error_to_media`, `error_to_text`.
+- `detail` argument to `HTTPError`.
 - Startup and shutdown events with `api.on()`.
 - Security guide.
 - Deployment guide.

--- a/bocadillo/error_handlers.py
+++ b/bocadillo/error_handlers.py
@@ -10,17 +10,26 @@ from .response import Response
 
 def error_to_html(req, res, exc: HTTPError):
     res.status_code = exc.status_code
-    res.html = f"<h1>{exc.status_code} {exc.status_phrase}</h1>"
+    html = f"<h1>{exc.title}</h1>"
+    if exc.detail:
+        html += f"\n<p>{exc.detail}</p>"
+    res.html = html
 
 
 def error_to_media(req, res, exc: HTTPError):
     res.status_code = exc.status_code
-    res.media = {"error": exc.status_phrase, "status": exc.status_code}
+    json = {"error": exc.title, "status": exc.status_code}
+    if exc.detail:
+        json["detail"] = exc.detail
+    res.media = json
 
 
 def error_to_text(req, res, exc: HTTPError):
     res.status_code = exc.status_code
-    res.text = f"{exc.status_code} {exc.status_phrase}"
+    text = exc.title
+    if exc.detail:
+        text += f"\n{exc.detail}"
+    res.text = text
 
 
 ErrorHandler = Callable[[Request, Response, Exception], None]

--- a/bocadillo/error_handlers.py
+++ b/bocadillo/error_handlers.py
@@ -18,10 +18,10 @@ def error_to_html(req, res, exc: HTTPError):
 
 def error_to_media(req, res, exc: HTTPError):
     res.status_code = exc.status_code
-    json = {"error": exc.title, "status": exc.status_code}
+    media = {"error": exc.title, "status": exc.status_code}
     if exc.detail:
-        json["detail"] = exc.detail
-    res.media = json
+        media["detail"] = exc.detail
+    res.media = media
 
 
 def error_to_text(req, res, exc: HTTPError):

--- a/bocadillo/exceptions.py
+++ b/bocadillo/exceptions.py
@@ -14,7 +14,7 @@ class HTTPError(Exception):
     request processing.
     """
 
-    def __init__(self, status: Union[int, HTTPStatus]):
+    def __init__(self, status: Union[int, HTTPStatus], detail: str = ""):
         if isinstance(status, int):
             status = HTTPStatus(status)
         else:
@@ -22,6 +22,7 @@ class HTTPError(Exception):
                 status, HTTPStatus
             ), f"Expected int or HTTPStatus, got {type(status)}"
         self._status = status
+        self.detail = detail
 
     @property
     def status_code(self) -> int:
@@ -33,8 +34,12 @@ class HTTPError(Exception):
         """Return the HTTP error's status phrase, i.e. `"Not Found"`."""
         return self._status.phrase
 
-    def __str__(self):
+    @property
+    def title(self) -> str:
         return f"{self.status_code} {self.status_phrase}"
+
+    def __str__(self):
+        return self.title
 
 
 class UnsupportedMediaType(Exception):

--- a/bocadillo/exceptions.py
+++ b/bocadillo/exceptions.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Union
+from typing import Union, Any
 
 from jinja2.exceptions import TemplateNotFound as _TemplateNotFound
 
@@ -14,7 +14,7 @@ class HTTPError(Exception):
     request processing.
     """
 
-    def __init__(self, status: Union[int, HTTPStatus], detail: str = ""):
+    def __init__(self, status: Union[int, HTTPStatus], detail: Any = ""):
         if isinstance(status, int):
             status = HTTPStatus(status)
         else:

--- a/docs/topics/request-handling/writing-views.md
+++ b/docs/topics/request-handling/writing-views.md
@@ -74,6 +74,10 @@ Forbidden
 
 As you can see, it returned a `403 Forbidden` response — this is `HTTPError(403)` in action.
 
+::: tip
+You can provide further details about what went wrong with the `detail` argument to `HTTPError`.
+:::
+
 ## Customizing error handling
 
 By default, Bocadillo sends plain text content in response to `HTTPError` exceptions raised in views.
@@ -87,7 +91,7 @@ from bocadillo.exceptions import HTTPError
 def error_to_media(req, res, exc: HTTPError):
     res.status = exc.status_code
     res.media = {
-        "error": exc.status_phrase,
+        "error": exc.detail,
         "status": exc.status_code,
     }
 ```


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #68

## Proposed changes

- Add a `detail` argument and attribute to `HTTPError`
- Update built-in error handlers to render the `detail` if given
- Update tests and docs
