### PR TITLE
Deal with malformed JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Bocadillo adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- `await req.json()` now returns a `400 Bad Request` error response if the input JSON is malformed.
+
 ## [v0.8.0] - 2018-12-26
 
 ### Added

--- a/bocadillo/request.py
+++ b/bocadillo/request.py
@@ -1,6 +1,23 @@
+from json import JSONDecodeError
+
 from starlette.requests import Request as _Request
 
+from .exceptions import HTTPError
 
-# Alias (for now)
+
 class Request(_Request):
-    pass
+    """The succulent request object."""
+
+    async def json(self):
+        """Parse the request body as JSON.
+
+        # Returns
+        json (dict): the result of `json.loads(await self.body())`.
+
+        # Raises
+        HTTPError(400): if the JSON is malformed.
+        """
+        try:
+            return await super().json()
+        except JSONDecodeError:
+            raise HTTPError(400, detail="JSON is malformed.")

--- a/docs/topics/request-handling/requests.md
+++ b/docs/topics/request-handling/requests.md
@@ -79,3 +79,7 @@ You can retrieve it in several ways, depending on the expected encoding:
 - Form data: `await req.form()`
 - JSON: `await req.json()`
 - Stream (advanced usage): `async for chunk in req.stream(): ...`
+
+::: tip How is malformed JSON handled?
+If the request body is not proper JSON, a `400 Bad Request` error response is returned.
+:::

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,13 @@
+import pytest
+
+from bocadillo import API
+
+
+@pytest.mark.parametrize("data, status", [("{", 400), ("{}", 200)])
+def test_parse_json(api: API, data: str, status: int):
+    @api.route("/")
+    class Index:
+        async def post(self, req, res):
+            res.media = await req.json()
+
+    assert api.client.post("/", data=data).status_code == status


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #73 

## Proposed changes

- Raise an `HTTPError(400)` exception if body could not be parsed as JSON.
- Tests and docs updates.
