### PR TITLE
Fix `url_for()` on recipes, add recipe redirections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ As a result, we strongly recommend you read this document carefully before upgra
 
 ## [Unreleased]
 
+### Added
+
+- Recipes now support redirections, e.g. `recipe.redirect(name="recipe:foo")`.
+
+### Fixed
+
+- Using `url_for()` in a template rendered from a recipe (e.g. `await recipe.template()`) used to raise an `UndefinedError`. This has been fixed.
+
 ## [v0.10.1] - 2019-01-21
 
 ### Changed

--- a/bocadillo/api.py
+++ b/bocadillo/api.py
@@ -189,6 +189,14 @@ class API(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
         self.apps[prefix] = app
 
     def recipe(self, recipe: RecipeBase):
+        """Apply a recipe.
+
+        # Parameters
+        recipe (Recipe or RecipeBook): a recipe to be applied to the API.
+
+        # See Also
+        - [Recipes](../agnostic/recipes.md)
+        """
         recipe(self)
 
     @property

--- a/bocadillo/api.py
+++ b/bocadillo/api.py
@@ -29,15 +29,14 @@ from .errors import HTTPError, HTTPErrorMiddleware, ServerErrorMiddleware
 from .media import Media
 from .meta import DocsMeta
 from .recipes import RecipeBase
-from .redirection import Redirection
 from .request import Request
 from .response import Response
-from .routing import HTTPRouter, WebSocketRouter
+from .routing import RoutingMixin
 from .staticfiles import static
 from .templates import TemplatesMixin
 
 
-class API(TemplatesMixin, metaclass=DocsMeta):
+class API(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
     """The all-mighty API class.
 
     This class implements the [ASGI](https://asgi.readthedocs.io) protocol.
@@ -118,10 +117,6 @@ class API(TemplatesMixin, metaclass=DocsMeta):
 
         # Mounted apps
         self.apps: Dict[str, Any] = {}
-
-        # Routers
-        self.http_router = HTTPRouter()
-        self.websocket_router = WebSocketRouter()
 
         # Test client
         self.client = self.build_client()
@@ -248,109 +243,6 @@ class API(TemplatesMixin, metaclass=DocsMeta):
             return handler
 
         return wrapper
-
-    def route(self, pattern: str, *, name: str = None, namespace: str = None):
-        """Register a new route by decorating a view.
-
-        # Parameters
-        pattern (str): an URL pattern.
-        methods (list of str):
-            An optional list of HTTP methods.
-            Defaults to `["get", "head"]`.
-            Ignored for class-based views.
-        name (str):
-            An optional name for the route.
-            If a route already exists for this name, it is replaced.
-            Defaults to a snake-cased version of the view's name.
-        namespace (str):
-            An optional namespace for the route. If given, it is prefixed to
-            the name and separated by a colon.
-
-        # See Also
-        - [check_route](#check-route) for the route validation algorithm.
-        """
-        return self.http_router.route(
-            pattern=pattern, name=name, namespace=namespace
-        )
-
-    def websocket_route(
-        self,
-        pattern: str,
-        *,
-        value_type: Optional[str] = None,
-        receive_type: Optional[str] = None,
-        send_type: Optional[str] = None,
-        caught_close_codes: Optional[Tuple[int]] = None,
-    ):
-        """Register a WebSocket route by decorating a view.
-
-        # Parameters
-        pattern (str): an URL pattern.
-
-        # See Also
-        - [WebSocket](./websockets.md#websocket) for a description of keyword
-        arguments.
-        """
-        # NOTE: use named keyword arguments instead of `**kwargs` to improve
-        # their accessibility (e.g. for IDE discovery).
-        return self.websocket_router.route(
-            pattern=pattern,
-            value_type=value_type,
-            receive_type=receive_type,
-            send_type=send_type,
-            caught_close_codes=caught_close_codes,
-        )
-
-    def url_for(self, name: str, **kwargs) -> str:
-        """Build the URL path for a named route.
-
-        # Parameters
-        name (str): the name of the route.
-        kwargs (dict): route parameters.
-
-        # Returns
-        url (str): the URL path for a route.
-
-        # Raises
-        HTTPError(404) : if no route exists for the given `name`.
-        """
-        route = self.http_router.routes.get(name)
-        if route is None:
-            raise HTTPError(404)
-        return route.url(**kwargs)
-
-    def redirect(
-        self,
-        *,
-        name: str = None,
-        url: str = None,
-        permanent: bool = False,
-        **kwargs,
-    ):
-        """Redirect to another HTTP route.
-
-        # Parameters
-        name (str): name of the route to redirect to.
-        url (str):
-            URL of the route to redirect to (required if `name` is omitted).
-        permanent (bool):
-            If `False` (the default), returns a temporary redirection (302).
-            If `True`, returns a permanent redirection (301).
-        kwargs (dict):
-            Route parameters.
-
-        # Raises
-        Redirection:
-            an exception that will be caught to trigger a redirection.
-
-        # See Also
-        - [Redirecting](../guides/http/redirecting.md)
-        """
-        if name is not None:
-            url = self.url_for(name=name, **kwargs)
-        else:
-            assert url is not None, "url is expected if no route name is given"
-        raise Redirection(url=url, permanent=permanent)
 
     def add_middleware(self, middleware_cls, **kwargs):
         """Register a middleware class.

--- a/bocadillo/misc.py
+++ b/bocadillo/misc.py
@@ -7,3 +7,11 @@ assets_dir = join(dirname(abspath(__file__)), "assets")
 def read_asset(filename: str) -> str:
     with open(join(assets_dir, filename), "r") as f:
         return f.read()
+
+
+def overrides(original):
+    def decorate(func):
+        func.__doc__ = original.__doc__
+        return func
+
+    return decorate

--- a/bocadillo/routing.py
+++ b/bocadillo/routing.py
@@ -1,21 +1,28 @@
 import inspect
 from functools import partial
-from typing import Callable, Union, Type, Any
-from typing import Optional, TypeVar, Generic, Dict
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from parse import parse
 from starlette.websockets import WebSocketClose
 
 from . import views
-from .app_types import HTTPApp
-from .app_types import Scope, Receive, Send
+from .app_types import HTTPApp, Receive, Scope, Send
 from .errors import HTTPError
 from .redirection import Redirection
 from .request import Request
 from .response import Response
-from .views import View, HandlerDoesNotExist
-from .websockets import WebSocketView, WebSocket
-
+from .views import HandlerDoesNotExist, View
+from .websockets import WebSocket, WebSocketView
 
 # Base classes
 
@@ -30,7 +37,7 @@ class BaseRoute:
     def __init__(self, pattern: str):
         if not pattern.startswith("/"):
             pattern = f"/{pattern}"
-        self._pattern = pattern
+        self.pattern = pattern
 
     def url(self, **kwargs) -> str:
         """Return full path for the given route parameters.
@@ -43,7 +50,7 @@ class BaseRoute:
             A full URL path obtained by formatting the route pattern with
             the provided route parameters.
         """
-        return self._pattern.format(**kwargs)
+        return self.pattern.format(**kwargs)
 
     def parse(self, path: str) -> Optional[dict]:
         """Parse an URL path against the route's URL pattern.
@@ -53,7 +60,7 @@ class BaseRoute:
             If the URL path matches the URL pattern, this is a dictionary
             containing the route parameters, otherwise None.
         """
-        result = parse(self._pattern, path)
+        result = parse(self.pattern, path)
         if result is not None:
             return result.named
         return None
@@ -89,9 +96,15 @@ class BaseRouter(Generic[_R]):
     def __init__(self):
         self.routes: Dict[str, _R] = {}
 
+    def _get_key(self, route: BaseRoute) -> str:
+        raise NotImplementedError
+
     def add_route(self, *args, **kwargs):
         """Register a route. Not implemented."""
         raise NotImplementedError
+
+    def add(self, route: _R):
+        self.routes[self._get_key(route)] = route
 
     def route(self, *args, **kwargs):
         """Register a route by decorating a view."""
@@ -114,6 +127,11 @@ class BaseRouter(Generic[_R]):
                 return RouteMatch(route=route, params=params)
         return None
 
+    def mount(self, other: "BaseRouter[_R]", root: str = ""):
+        for route in other.routes.values():
+            route.pattern = root + route.pattern
+            self.add(route)
+
 
 # HTTP
 
@@ -131,12 +149,12 @@ class HTTPRoute(BaseRoute):
 
     def __init__(self, pattern: str, view: View, name: str):
         super().__init__(pattern)
-        self._view = view
-        self._name = name
+        self.view = view
+        self.name = name
 
     async def __call__(self, req: Request, res: Response, **params) -> None:
         try:
-            await self._view(req, res, **params)
+            await self.view(req, res, **params)
         except HandlerDoesNotExist as e:
             raise HTTPError(405) from e
 
@@ -148,6 +166,9 @@ class HTTPRouter(HTTPApp, BaseRouter[HTTPRoute]):
 
     Note: routes are stored by `name` instead of `pattern`.
     """
+
+    def _get_key(self, route: HTTPRoute) -> str:
+        return route.name
 
     def add_route(
         self,
@@ -203,7 +224,7 @@ class HTTPRouter(HTTPApp, BaseRouter[HTTPRoute]):
             name = namespace + ":" + name
 
         route = HTTPRoute(pattern=pattern, view=view, name=name)
-        self.routes[name] = route
+        self.add(route)
 
         return route
 
@@ -236,7 +257,7 @@ class WebSocketRoute(BaseRoute):
 
     def __init__(self, pattern: str, view: WebSocketView, **kwargs):
         super().__init__(pattern)
-        self._view = view
+        self.view = view
         self._ws_kwargs = kwargs
 
     async def __call__(
@@ -244,7 +265,7 @@ class WebSocketRoute(BaseRoute):
     ):
         ws = WebSocket(scope, receive, send, **self._ws_kwargs)
         try:
-            await self._view(ws, **params)
+            await self.view(ws, **params)
         except BaseException:
             await ws.ensure_closed(1011)
             raise
@@ -255,6 +276,9 @@ class WebSocketRouter(BaseRouter[WebSocketRoute]):
 
     Extends [BaseRouter](#baserouter).
     """
+
+    def _get_key(self, route: WebSocketRoute) -> str:
+        return route.pattern
 
     def add_route(self, view: WebSocketView, pattern: str, **kwargs):
         """Register a WebSocket route.
@@ -267,7 +291,7 @@ class WebSocketRouter(BaseRouter[WebSocketRoute]):
         route (WebSocketRoute): the registered route.
         """
         route = WebSocketRoute(pattern=pattern, view=view, **kwargs)
-        self.routes[pattern] = route
+        self.add(route)
         return route
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
@@ -279,3 +303,115 @@ class WebSocketRouter(BaseRouter[WebSocketRoute]):
             await WebSocketClose(code=403)(receive, send)
         else:
             await match.route(scope, receive, send, **match.params)
+
+
+class RoutingMixin:
+    """Provide HTTP and WebSocket routing to an application class."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.http_router = HTTPRouter()
+        self.websocket_router = WebSocketRouter()
+
+    def route(self, pattern: str, *, name: str = None, namespace: str = None):
+        """Register a new route by decorating a view.
+
+        # Parameters
+        pattern (str): an URL pattern.
+        methods (list of str):
+            An optional list of HTTP methods.
+            Defaults to `["get", "head"]`.
+            Ignored for class-based views.
+        name (str):
+            An optional name for the route.
+            If a route already exists for this name, it is replaced.
+            Defaults to a snake-cased version of the view's name.
+        namespace (str):
+            An optional namespace for the route. If given, it is prefixed to
+            the name and separated by a colon.
+
+        # See Also
+        - [check_route](#check-route) for the route validation algorithm.
+        """
+        return self.http_router.route(
+            pattern=pattern, name=name, namespace=namespace
+        )
+
+    def websocket_route(
+        self,
+        pattern: str,
+        *,
+        value_type: Optional[str] = None,
+        receive_type: Optional[str] = None,
+        send_type: Optional[str] = None,
+        caught_close_codes: Optional[Tuple[int]] = None,
+    ):
+        """Register a WebSocket route by decorating a view.
+
+        # Parameters
+        pattern (str): an URL pattern.
+
+        # See Also
+        - [WebSocket](./websockets.md#websocket) for a description of keyword
+        arguments.
+        """
+        # NOTE: use named keyword arguments instead of `**kwargs` to improve
+        # their accessibility (e.g. for IDE discovery).
+        return self.websocket_router.route(
+            pattern=pattern,
+            value_type=value_type,
+            receive_type=receive_type,
+            send_type=send_type,
+            caught_close_codes=caught_close_codes,
+        )
+
+    def url_for(self, name: str, **kwargs) -> str:
+        """Build the URL path for a named route.
+
+        # Parameters
+        name (str): the name of the route.
+        kwargs (dict): route parameters.
+
+        # Returns
+        url (str): the URL path for a route.
+
+        # Raises
+        HTTPError(404) : if no route exists for the given `name`.
+        """
+        route = self.http_router.routes.get(name)
+        if route is None:
+            raise HTTPError(404)
+        return route.url(**kwargs)
+
+    def redirect(
+        self,
+        *,
+        name: str = None,
+        url: str = None,
+        permanent: bool = False,
+        **kwargs,
+    ):
+        """Redirect to another HTTP route.
+
+        # Parameters
+        name (str): name of the route to redirect to.
+        url (str):
+            URL of the route to redirect to (required if `name` is omitted).
+        permanent (bool):
+            If `False` (the default), returns a temporary redirection (302).
+            If `True`, returns a permanent redirection (301).
+        kwargs (dict):
+            Route parameters.
+
+        # Raises
+        Redirection:
+            an exception that will be caught to trigger a redirection.
+
+        # See Also
+        - [Redirecting](../guides/http/redirecting.md)
+        """
+        if name is not None:
+            url = self.url_for(name=name, **kwargs)
+        else:
+            assert url is not None, "url is expected if no route name is given"
+        raise Redirection(url=url, permanent=permanent)

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -139,6 +139,20 @@ __Parameters__
 - __prefix (str)__: A path prefix where the app should be mounted, e.g. `"/myapp"`.
 - __app__: An object implementing [WSGI](https://wsgi.readthedocs.io) or [ASGI](https://asgi.readthedocs.io) protocol.
 
+### recipe
+```python
+API.recipe(self, recipe: bocadillo.recipes.RecipeBase)
+```
+Apply a recipe.
+
+__Parameters__
+
+- __recipe (Recipe or RecipeBook)__: a recipe to be applied to the API.
+
+__See Also__
+
+- [Recipes](../agnostic/recipes.md)
+
 ### add_error_handler
 ```python
 API.add_error_handler(self, exception_cls: Type[Exception], handler: Callable[[bocadillo.request.Request, bocadillo.response.Response, Exception], NoneType])
@@ -163,91 +177,6 @@ Register a new error handler (decorator syntax).
 __See Also__
 
 - [add_error_handler](#add-error-handler)
-
-### route
-```python
-API.route(self, pattern: str, *, name: str = None, namespace: str = None)
-```
-Register a new route by decorating a view.
-
-__Parameters__
-
-- __pattern (str)__: an URL pattern.
-- __methods (list of str)__:
-    An optional list of HTTP methods.
-    Defaults to `["get", "head"]`.
-    Ignored for class-based views.
-- __name (str)__:
-    An optional name for the route.
-    If a route already exists for this name, it is replaced.
-    Defaults to a snake-cased version of the view's name.
-- __namespace (str)__:
-    An optional namespace for the route. If given, it is prefixed to
-    the name and separated by a colon.
-
-__See Also__
-
-- [check_route](#check-route) for the route validation algorithm.
-
-### websocket_route
-```python
-API.websocket_route(self, pattern: str, *, value_type: Union[str, NoneType] = None, receive_type: Union[str, NoneType] = None, send_type: Union[str, NoneType] = None, caught_close_codes: Union[Tuple[int], NoneType] = None)
-```
-Register a WebSocket route by decorating a view.
-
-__Parameters__
-
-- __pattern (str)__: an URL pattern.
-
-__See Also__
-
-- [WebSocket](./websockets.md#websocket) for a description of keyword
-arguments.
-
-### url_for
-```python
-API.url_for(self, name: str, **kwargs) -> str
-```
-Build the URL path for a named route.
-
-__Parameters__
-
-- __name (str)__: the name of the route.
-- __kwargs (dict)__: route parameters.
-
-__Returns__
-
-`url (str)`: the URL path for a route.
-
-__Raises__
-
-- `HTTPError(404) `: if no route exists for the given `name`.
-
-### redirect
-```python
-API.redirect(self, *, name: str = None, url: str = None, permanent: bool = False, **kwargs)
-```
-Redirect to another HTTP route.
-
-__Parameters__
-
-- __name (str)__: name of the route to redirect to.
-- __url (str)__:
-    URL of the route to redirect to (required if `name` is omitted).
-- __permanent (bool)__:
-    If `False` (the default), returns a temporary redirection (302).
-    If `True`, returns a permanent redirection (301).
-- __kwargs (dict)__:
-    Route parameters.
-
-__Raises__
-
-- `Redirection`:
-    an exception that will be caught to trigger a redirection.
-
-__See Also__
-
-- [Redirecting](../guides/http/redirecting.md)
 
 ### add_middleware
 ```python
@@ -310,6 +239,65 @@ async def shutdown():
 api.on("shutdown", shutdown)
 ```
 
+### route
+```python
+API.route(self, pattern: str, *, name: str = None, namespace: str = None)
+```
+Register a new route by decorating a view.
+
+__Parameters__
+
+- __pattern (str)__: an URL pattern.
+- __methods (list of str)__:
+    An optional list of HTTP methods.
+    Defaults to `["get", "head"]`.
+    Ignored for class-based views.
+- __name (str)__:
+    An optional name for the route.
+    If a route already exists for this name, it is replaced.
+    Defaults to a snake-cased version of the view's name.
+- __namespace (str)__:
+    An optional namespace for the route. If given, it is prefixed to
+    the name and separated by a colon.
+
+__See Also__
+
+- [check_route](#check-route) for the route validation algorithm.
+
+### websocket_route
+```python
+API.websocket_route(self, pattern: str, *, value_type: Union[str, NoneType] = None, receive_type: Union[str, NoneType] = None, send_type: Union[str, NoneType] = None, caught_close_codes: Union[Tuple[int], NoneType] = None)
+```
+Register a WebSocket route by decorating a view.
+
+__Parameters__
+
+- __pattern (str)__: an URL pattern.
+
+__See Also__
+
+- [WebSocket](./websockets.md#websocket) for a description of keyword
+arguments.
+
+### url_for
+```python
+API.url_for(self, name: str, **kwargs) -> str
+```
+Build the URL path for a named route.
+
+__Parameters__
+
+- __name (str)__: the name of the route.
+- __kwargs (dict)__: route parameters.
+
+__Returns__
+
+`url (str)`: the URL path for a route.
+
+__Raises__
+
+- `HTTPError(404) `: if no route exists for the given `name`.
+
 ### run
 ```python
 API.run(self, host: str = None, port: int = None, debug: bool = False, log_level: str = 'info', _run: Callable = None, **kwargs)
@@ -342,4 +330,30 @@ __See Also__
 - [Debug mode](../guides/api.md#debug-mode)
 - [Uvicorn settings](https://www.uvicorn.org/settings/) for all
 available keyword arguments.
+
+### redirect
+```python
+API.redirect(self, *, name: str = None, url: str = None, permanent: bool = False, **kwargs)
+```
+Redirect to another HTTP route.
+
+__Parameters__
+
+- __name (str)__: name of the route to redirect to.
+- __url (str)__:
+    URL of the route to redirect to (required if `name` is omitted).
+- __permanent (bool)__:
+    If `False` (the default), returns a temporary redirection (302).
+    If `True`, returns a permanent redirection (301).
+- __kwargs (dict)__:
+    Route parameters.
+
+__Raises__
+
+- `Redirection`:
+    an exception that will be caught to trigger a redirection.
+
+__See Also__
+
+- [Redirecting](../guides/http/redirecting.md)
 

--- a/docs/api/recipes.md
+++ b/docs/api/recipes.md
@@ -29,28 +29,51 @@ This is built from the `templates_dir` parameter.
 
 ### route
 ```python
-Recipe.route(self, pattern: str, **kwargs)
+Recipe.route(self, pattern: str, **kwargs) -> bocadillo.routing.HTTPRoute
 ```
-Register a route on the recipe.
+Register a new route by decorating a view.
 
-Accepts the same arguments as `API.route()`, except `namespace` which
-will be given the value of the recipe's `name`.
+__Parameters__
+
+- __pattern (str)__: an URL pattern.
+- __methods (list of str)__:
+    An optional list of HTTP methods.
+    Defaults to `["get", "head"]`.
+    Ignored for class-based views.
+- __name (str)__:
+    An optional name for the route.
+    If a route already exists for this name, it is replaced.
+    Defaults to a snake-cased version of the view's name.
+- __namespace (str)__:
+    An optional namespace for the route. If given, it is prefixed to
+    the name and separated by a colon.
 
 __See Also__
 
-- [API.route()](./api.md#route)
+- [check_route](#check-route) for the route validation algorithm.
 
 ### websocket_route
 ```python
-Recipe.websocket_route(self, pattern: str, **kwargs)
+Recipe.websocket_route(self, pattern: str, **kwargs) -> bocadillo.routing.WebSocketRoute
 ```
-Register a WebSocket route on the recipe.
+Register a WebSocket route by decorating a view.
 
-Accepts the same arguments as `API.websocket_route()`.
+__Parameters__
+
+- __pattern (str)__: an URL pattern.
 
 __See Also__
 
-- [API.websocket_route()](./api.md#websocket-route)
+- [WebSocket](./websockets.md#websocket) for a description of keyword
+arguments.
+
+### book
+```python
+Recipe.book(*recipes: 'Recipe', prefix: str) -> 'RecipeBook'
+```
+Build a book of recipes.
+
+Shortcut for `RecipeBook(recipes, prefix)`.
 
 ### template
 ```python
@@ -72,14 +95,6 @@ __Parameters__
 - __kwargs (dict)__:
     Context variables to inject in the template.
 
-### book
-```python
-Recipe.book(*recipes: 'Recipe', prefix: str) -> 'RecipeBook'
-```
-Build a book of recipes.
-
-Shortcut for `RecipeBook(recipes, prefix)`.
-
 ### template_sync
 ```python
 Recipe.template_sync(self, name_: str, context: dict = None, **kwargs) -> str
@@ -99,6 +114,51 @@ __Parameters__
 - __source (str)__: a template given as a string.
 
 For other parameters, see `API.template()`.
+
+### url_for
+```python
+Recipe.url_for(self, name: str, **kwargs) -> str
+```
+Build the URL path for a named route.
+
+__Parameters__
+
+- __name (str)__: the name of the route.
+- __kwargs (dict)__: route parameters.
+
+__Returns__
+
+`url (str)`: the URL path for a route.
+
+__Raises__
+
+- `HTTPError(404) `: if no route exists for the given `name`.
+
+### redirect
+```python
+Recipe.redirect(self, *, name: str = None, url: str = None, permanent: bool = False, **kwargs)
+```
+Redirect to another HTTP route.
+
+__Parameters__
+
+- __name (str)__: name of the route to redirect to.
+- __url (str)__:
+    URL of the route to redirect to (required if `name` is omitted).
+- __permanent (bool)__:
+    If `False` (the default), returns a temporary redirection (302).
+    If `True`, returns a permanent redirection (301).
+- __kwargs (dict)__:
+    Route parameters.
+
+__Raises__
+
+- `Redirection`:
+    an exception that will be caught to trigger a redirection.
+
+__See Also__
+
+- [Redirecting](../guides/http/redirecting.md)
 
 ## RecipeBook
 ```python

--- a/docs/api/routing.md
+++ b/docs/api/routing.md
@@ -165,7 +165,7 @@ Extends [BaseRouter](#baserouter).
 
 ### add_route
 ```python
-WebSocketRouter.add_route(self, pattern: str, view: Callable[[bocadillo.websockets.WebSocket], Awaitable[NoneType]], **kwargs)
+WebSocketRouter.add_route(self, view: Callable[[bocadillo.websockets.WebSocket], Awaitable[NoneType]], pattern: str, **kwargs)
 ```
 Register a WebSocket route.
 
@@ -177,4 +177,94 @@ __Parameters__
 __Returns__
 
 `route (WebSocketRoute)`: the registered route.
+
+## RoutingMixin
+```python
+RoutingMixin(self, **kwargs)
+```
+Provide HTTP and WebSocket routing to an application class.
+### route
+```python
+RoutingMixin.route(self, pattern: str, *, name: str = None, namespace: str = None)
+```
+Register a new route by decorating a view.
+
+__Parameters__
+
+- __pattern (str)__: an URL pattern.
+- __methods (list of str)__:
+    An optional list of HTTP methods.
+    Defaults to `["get", "head"]`.
+    Ignored for class-based views.
+- __name (str)__:
+    An optional name for the route.
+    If a route already exists for this name, it is replaced.
+    Defaults to a snake-cased version of the view's name.
+- __namespace (str)__:
+    An optional namespace for the route. If given, it is prefixed to
+    the name and separated by a colon.
+
+__See Also__
+
+- [check_route](#check-route) for the route validation algorithm.
+
+### websocket_route
+```python
+RoutingMixin.websocket_route(self, pattern: str, *, value_type: Union[str, NoneType] = None, receive_type: Union[str, NoneType] = None, send_type: Union[str, NoneType] = None, caught_close_codes: Union[Tuple[int], NoneType] = None)
+```
+Register a WebSocket route by decorating a view.
+
+__Parameters__
+
+- __pattern (str)__: an URL pattern.
+
+__See Also__
+
+- [WebSocket](./websockets.md#websocket) for a description of keyword
+arguments.
+
+### url_for
+```python
+RoutingMixin.url_for(self, name: str, **kwargs) -> str
+```
+Build the URL path for a named route.
+
+__Parameters__
+
+- __name (str)__: the name of the route.
+- __kwargs (dict)__: route parameters.
+
+__Returns__
+
+`url (str)`: the URL path for a route.
+
+__Raises__
+
+- `HTTPError(404) `: if no route exists for the given `name`.
+
+### redirect
+```python
+RoutingMixin.redirect(self, *, name: str = None, url: str = None, permanent: bool = False, **kwargs)
+```
+Redirect to another HTTP route.
+
+__Parameters__
+
+- __name (str)__: name of the route to redirect to.
+- __url (str)__:
+    URL of the route to redirect to (required if `name` is omitted).
+- __permanent (bool)__:
+    If `False` (the default), returns a temporary redirection (302).
+    If `True`, returns a permanent redirection (301).
+- __kwargs (dict)__:
+    Route parameters.
+
+__Raises__
+
+- `Redirection`:
+    an exception that will be caught to trigger a redirection.
+
+__See Also__
+
+- [Redirecting](../guides/http/redirecting.md)
 

--- a/docs/guides/agnostic/recipes.md
+++ b/docs/guides/agnostic/recipes.md
@@ -52,13 +52,21 @@ This will add all the routes in the `tacos` recipe under the `/tacos` path, mean
 
 Recipes expose the following features, which can be used just as you would on the `API` object:
 
-- [Routes](../http/routing.md), e.g. `@recipe.route()`.
+- [HTTP routes](../http/routing.md), e.g. `@recipe.route()`.
 - [WebSocket routes](../websockets/routing.md), .e.g `@recipe.websocket_route()`.
+- [HTTP redirects](../http/redirecting.md), e.g. `recipe.redirect(name="recipe:foo")`.
 - [Templates](./templates.md), e.g. `await recipe.template()`.
-- [Hooks](../http/hooks.md), e.g. `@recipe.before()`.
 
 ::: tip
-If your recipe needs to use its own templates, you should pass an adequate `templates_dir` to the `Recipe` constructor. Otherwise, the same `templates_dir` as the `API` will be used.
+The `url_for()` template global is also available from recipes, and works no differently than for the `API`.
+
+This means that you must use the namespaced name if the target route has been registered on the recipe, e.g. `url_for("recipe:foo")`.
+
+See [Reversing named routes](../http/routing.md#reversing-named-routes) for more information on `url_for()`.
+:::
+
+::: tip
+If your recipe needs to use its own templates, you can pass an adequate `templates_dir` to the `Recipe` constructor. Otherwise, the same `templates_dir` as the `API` will be used.
 :::
 
 ::: tip
@@ -66,7 +74,7 @@ You can decorate your recipe views with [hooks](../http/hooks.md) as usual.
 :::
 
 ::: warning CAVEAT
-Note that recipes apply the exact same [routing algorithm](../http/routing.md#how-are-requests-processed) than the `API`. In particular, the `/` route will be mounted on the `API` at `/{prefix}/`, *not* `/prefix`. Accessing `/prefix` would return a 404 error, as per the routing algorithm.
+Note that recipes apply the exact same [routing algorithm](../http/routing.md#how-are-requests-processed) than the `API`. In particular, the `/` route will be mounted on the `API` at `/{prefix}/`, *not* `/{prefix}`. Accessing `/{prefix}` would return a 404 error, as per the routing algorithm.
 :::
 
 ## Recipe books
@@ -162,25 +170,5 @@ You'll end up with the following routes:
 - `/entities/companies/`
 
 ::: warning
-Recipe books do not expose the `API` API. They only serve as a means of grouping recipes together.
+Recipe books do not expose any specific features. They only serve as a means of grouping recipes together.
 :::
-
-## Named routes and `url_for`
-
-If a recipe defines a named route, you'll need to prefix its name with the name of the recipe when building the full URL using `api.url_for()`.
-
-For example:
-
-```python{7}
-from bocadillo import Recipe
-
-tacos = Recipe('tacos')
-
-@tacos.route('/')
-async def root(req, res):
-    tacos.redirect('tacos.taco-detail', pk=4)
-
-@tacos.route('/{pk}', name='taco-detail')
-async def retrieve_taco(req, res, pk):
-    res.media = {'id': pk, 'recipe': 'tacos'}
-```

--- a/tests/test_recipes_routing.py
+++ b/tests/test_recipes_routing.py
@@ -40,3 +40,21 @@ def test_url_for():
         pass
 
     assert numbers.url_for("numbers:real") == "/numbers/real"
+
+
+def test_redirect(api: API):
+    numbers = Recipe("numbers")
+
+    @numbers.route("/R")
+    async def R(req, res):
+        numbers.redirect(name="numbers:real")
+
+    @numbers.route("/real")
+    async def real(req, res):
+        res.text = "inf"
+
+    api.recipe(numbers)
+
+    response = api.client.get("/numbers/R")
+    assert response.status_code == 200
+    assert response.text == "inf"

--- a/tests/test_recipes_routing.py
+++ b/tests/test_recipes_routing.py
@@ -30,3 +30,13 @@ def test_if_prefix_then_routes_mounted_at_prefix(api: API):
 def test_if_prefix_does_not_start_with_slash_then_error_raised():
     with pytest.raises(AssertionError):
         Recipe("numbers", prefix="numbers-yo")
+
+
+def test_url_for():
+    numbers = Recipe("numbers")
+
+    @numbers.route("/real")
+    async def real(req, res):
+        pass
+
+    assert numbers.url_for("numbers:real") == "/numbers/real"

--- a/tests/test_recipes_templates.py
+++ b/tests/test_recipes_templates.py
@@ -67,7 +67,7 @@ def test_use_url_for(api: API):
     @foo.route("/fez")
     async def fez(req, res):
         res.html = foo.template_string(
-            "<a href=\"{{ url_for('bar') }}>To bar</a>"
+            "<a href=\"{{ url_for('foo:bar') }}\">To bar</a>"
         )
 
     api.recipe(foo)

--- a/tests/test_recipes_templates.py
+++ b/tests/test_recipes_templates.py
@@ -55,3 +55,23 @@ def test_render_sync_template_in_recipe_route(
     response = api.client.get("/numbers/sync")
     assert response.status_code == 200
     assert response.text == template_file.rendered
+
+
+def test_use_url_for(api: API):
+    foo = Recipe("foo")
+
+    @foo.route("/bar")
+    async def bar(req, res):
+        pass
+
+    @foo.route("/fez")
+    async def fez(req, res):
+        res.html = foo.template_string(
+            "<a href=\"{{ url_for('bar') }}>To bar</a>"
+        )
+
+    api.recipe(foo)
+
+    response = api.client.get("/foo/fez")
+    assert response.status_code == 200
+    assert response.text == '<a href="/foo/bar">To bar</a>'


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #114. Fixes #111.

Involved quite a bit of refactoring of the routing implementation. It is now exactly the same on `API` and `Recipe` using a common `RoutingMixin`. Even API reference is the same! :tada: