### PR TITLE
Fix form parsing

### DIFF
--- a/docs/guides/http/requests.md
+++ b/docs/guides/http/requests.md
@@ -55,8 +55,7 @@ req.headers['X-App']  # 'Bocadillo'
 
 ## Query parameters
 
-Query parameters are available at `req.query_params`, an immutable Python
-dictionary-like object.
+Query parameters are available at `req.query_params`, an immutable `MultiDict`, i.e. a dictionary-like object that supports having multiple elements per key.
 
 ```bash
 curl "http://localhost:8000?add=1&sub=2&sub=3"
@@ -87,9 +86,13 @@ only be used inside **asynchronous** views.
 
 You can retrieve it in several ways, depending on the expected encoding:
 
-- Bytes: `await req.body()`
-- Form data: `await req.form()`
-- JSON: `await req.json()`
+| Body type | Invocation         | Return type      |
+| --------- | ------------------ | ---------------- |
+| Raw       | `await req.body()` | `bytes`          |
+| Form data | `await req.form()` | `MultiDict`\*    |
+| JSON      | `await req.json()` | `list` or `dict` |
+
+\*This is a dictionary-like object that behaves like [`query_params`](#query-parameters). It contains both form data and multipart (upload) data.
 
 ::: tip How is malformed JSON handled?
 If the request body is not proper JSON, a `400 Bad Request` error response is returned.

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         "whitenoise",
         "requests",
         "parse",
+        "python-multipart",
         "websockets>=6.0",
     ],
     url=DOCS,

--- a/tests/test_form_parsing.py
+++ b/tests/test_form_parsing.py
@@ -1,0 +1,16 @@
+from starlette.datastructures import FormData
+
+from bocadillo import API
+
+
+def test_form_parsing(api: API):
+    @api.route("/")
+    async def index(req, res):
+        form = await req.form()
+        assert isinstance(form, FormData)
+        # not actually a dict, so not immediately JSON-serializable
+        res.media = dict(form)
+
+    r = api.client.get("/", data={"foo": "bar"})
+    assert r.status_code == 200
+    assert r.json() == {"foo": "bar"}


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #161 

## Proposed changes

- Add `python-multipart` as a dependency to allow to use `await req.form()`.
- Basic test for form parsing.
- Update docs on the request body.
