### PR TITLE
Make Recipe a subclass of App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ As a result, we strongly recommend you read this document carefully before upgra
 - Browser-downloadable responses (aka attachments) with `res.attachment`.
 - File responses with `res.file()`.
 - Generic templating with `bocadillo.templates.Templates`.
+- Recipes are now just apps: they expose all the parameters, attributes and methods that an `App` exposes.
 
 ### Fixed
 
@@ -27,7 +28,7 @@ As a result, we strongly recommend you read this document carefully before upgra
 
 ### Changed
 
-- `App` is the main application class or which `API` is now an alias of.
+- `App` is the main application class of which `API` is now an alias of.
 - Content types are now available on the `bocadillo.constants.CONTENT_TYPE` enum, instead of `bocadillo.media.Media`.
 
 ### Removed
@@ -36,7 +37,7 @@ As a result, we strongly recommend you read this document carefully before upgra
 
 ### Deprecated
 
-- `API` has been deprecated in favor `App`, and will be removed in v0.13.0.
+- `API` has been deprecated in favor of `App`, and will be removed in v0.13.0.
 - The `.template[_sync | _string]` methods on `API` and `Recipe` have been deprecated in favor of `Templates`. They will be removed in v0.13.0.
 
 ## [v0.11.2] - 2019-02-21

--- a/bocadillo/applications.py
+++ b/bocadillo/applications.py
@@ -46,7 +46,7 @@ from .routing import RoutingMixin
 from .staticfiles import static
 from .templates import TemplatesMixin
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .recipes import Recipe
 
 
@@ -215,7 +215,8 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
         except HTTPError as exc:
             app_name, _, name = name.partition(":")
 
-            if not app_name:
+            if not name:
+                # No app name given.
                 raise exc from None
 
             return self._url_for_app(app_name, name, **kwargs)

--- a/bocadillo/applications.py
+++ b/bocadillo/applications.py
@@ -136,7 +136,7 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
         # Base ASGI app
         self.asgi = self.dispatch
 
-        # Mounted apps
+        # Mounted (children) apps
         self._prefix_to_app: Dict[str, Any] = {}
         self._name_to_prefix_and_app: Dict[str, Tuple[str, App]] = {}
 

--- a/bocadillo/misc.py
+++ b/bocadillo/misc.py
@@ -1,18 +1,9 @@
 from os.path import join, dirname, abspath
-from typing import Callable
 
-assets_dir = join(dirname(abspath(__file__)), "assets")
+_ASSETS_DIR = join(dirname(abspath(__file__)), "assets")
 
 
 # TODO make async using aiofiles?
 def read_asset(filename: str) -> str:
-    with open(join(assets_dir, filename), "r") as f:
+    with open(join(_ASSETS_DIR, filename), "r") as f:
         return f.read()
-
-
-def overrides(original: Callable) -> Callable:
-    def decorate(func):
-        func.__doc__ = original.__doc__
-        return func
-
-    return decorate

--- a/bocadillo/recipes.py
+++ b/bocadillo/recipes.py
@@ -34,7 +34,7 @@ class Recipe(App):
         Defaults to `"/" + name`.
     """
 
-    def __init__(self, name: str = None, prefix: str = None, **kwargs):
+    def __init__(self, name: str, prefix: str = None, **kwargs):
         super().__init__(name=name, **kwargs)
 
         if prefix is None:

--- a/bocadillo/recipes.py
+++ b/bocadillo/recipes.py
@@ -45,8 +45,8 @@ class Recipe(App):
         # DEPRECATED: 0.13.0
         self._templates_dir_given = "templates_dir" in kwargs
 
-    def url_for(self, name: str, **kwargs) -> str:
-        return self.prefix + super().url_for(name, **kwargs)
+    def _get_own_url_for(self, name: str, **kwargs) -> str:
+        return self.prefix + super()._get_own_url_for(name, **kwargs)
 
     def apply(self, app: App, root: str = ""):
         """Apply the recipe to an application."""

--- a/bocadillo/recipes.py
+++ b/bocadillo/recipes.py
@@ -1,10 +1,6 @@
-from typing import Any, Sequence
+from typing import Sequence
 
-
-from .meta import DocsMeta
-from .misc import overrides
-from .routing import HTTPRoute, RoutingMixin, WebSocketRoute
-from .templates import TemplatesMixin
+from .applications import App
 
 
 class RecipeBase:
@@ -14,7 +10,7 @@ class RecipeBase:
         assert prefix.startswith("/"), "recipe prefix must start with '/'"
         self.prefix = prefix
 
-    def __call__(self, app, root: str = ""):
+    def apply(self, app: App, root: str = ""):
         """Apply the recipe to an application.
 
         Should be implemented by subclasses.
@@ -26,7 +22,7 @@ class RecipeBase:
         raise NotImplementedError
 
 
-class Recipe(TemplatesMixin, RoutingMixin, RecipeBase, metaclass=DocsMeta):
+class Recipe(App):
     """A grouping of capabilities that can be merged back into an application.
 
     # Parameters
@@ -38,39 +34,28 @@ class Recipe(TemplatesMixin, RoutingMixin, RecipeBase, metaclass=DocsMeta):
         Defaults to `"/" + name`.
     """
 
-    def __init__(self, name: str, prefix: str = None, **kwargs):
+    def __init__(self, name: str = None, prefix: str = None, **kwargs):
+        super().__init__(name=name, **kwargs)
+
         if prefix is None:
             prefix = f"/{name}"
-        super().__init__(prefix=prefix, **kwargs)
+        assert prefix.startswith("/"), "recipe prefix must start with '/'"
+
+        self.prefix = prefix
         # DEPRECATED: 0.13.0
         self._templates_dir_given = "templates_dir" in kwargs
-        self.name = name
 
-    def get_template_globals(self):
-        # DEPRECATED: 0.13.0
-        return {"url_for": self.url_for}
+    def url_for(self, name: str, **kwargs) -> str:
+        return self.prefix + super().url_for(name, **kwargs)
 
-    @overrides(RoutingMixin.route)
-    def route(self, pattern: str, **kwargs) -> HTTPRoute:
-        kwargs["namespace"] = self.name
-        return super().route(self.prefix + pattern, **kwargs)
-
-    @overrides(RoutingMixin.websocket_route)
-    def websocket_route(self, pattern: str, **kwargs) -> WebSocketRoute:
-        return super().websocket_route(self.prefix + pattern, **kwargs)
-
-    def __call__(self, obj: Any, root: str = ""):
-        """Apply the recipe to an object.
-        
-        Said object must be a subclass `RoutingMixin` and `TemplateMixin`.
-        """
-        obj.http_router.mount(self.http_router, root=root)
-        obj.websocket_router.mount(self.websocket_router, root=root)
+    def apply(self, app: App, root: str = ""):
+        """Apply the recipe to an application."""
+        app.mount(prefix=root + self.prefix, app=self)
 
         # DEPRECATED: 0.13.0
         # Look for templates where the app does, if not specified
         if not self._templates_dir_given:
-            self.templates_dir = obj.templates_dir
+            self.templates_dir = app.templates_dir  # type: ignore
 
     @classmethod
     def book(cls, *recipes: "Recipe", prefix: str) -> "RecipeBook":
@@ -94,7 +79,7 @@ class RecipeBook(RecipeBase):
         super().__init__(prefix)
         self.recipes = recipes
 
-    def __call__(self, obj: Any, root: str = ""):
-        """Apply the recipe book to an object."""
+    def apply(self, app: App, root: str = ""):
+        """Apply the recipe book to an application."""
         for recipe in self.recipes:
-            recipe(obj, root=root + self.prefix)
+            recipe.apply(app, root=root + self.prefix)

--- a/bocadillo/templates.py
+++ b/bocadillo/templates.py
@@ -141,6 +141,7 @@ _REPLACED_BY = ReplacedBy(
 )
 
 
+@_REPLACED_BY("Templates", "#templates")
 class TemplatesMixin:
     """Provide templating capabilities to an application class."""
 

--- a/bocadillo/templates.py
+++ b/bocadillo/templates.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager, suppress
-from typing import Any, Optional, cast
+from typing import Any, Dict, Optional, cast
 
 from jinja2 import Environment, FileSystemLoader, Template
 
@@ -141,17 +141,16 @@ _REPLACED_BY = ReplacedBy(
 )
 
 
-@_REPLACED_BY("Templates", "#templates")
 class TemplatesMixin:
     """Provide templating capabilities to an application class."""
 
-    def __init__(self, templates_dir: str = DEFAULT_TEMPLATES_DIR, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, templates_dir: str = DEFAULT_TEMPLATES_DIR):
+        super().__init__()
         self._templates = Templates(
             directory=templates_dir, context=self.get_template_globals()
         )
 
-    def get_template_globals(self) -> dict:
+    def get_template_globals(self) -> Dict[str, Any]:
         return {}
 
     @property  # type: ignore

--- a/docs/guides/agnostic/recipes.md
+++ b/docs/guides/agnostic/recipes.md
@@ -59,7 +59,10 @@ This includes, but is not limited to:
 - [Redirecting](../http/redirecting.md), e.g. `recipe.redirect(...)`
 - [Middleware](../http/middleware.md), e.g. `recipe.add_middleware(...)`.
 
-Note, however, that [lifespan event handlers](./events.md) only get called on the root application.
+Note, however, that:
+
+- [Lifespan event handlers](./events.md) only get called on the root application.
+- Recipes cannot be nested.
 
 **Caveat: root routes on recipes**
 

--- a/docs/guides/agnostic/recipes.md
+++ b/docs/guides/agnostic/recipes.md
@@ -92,10 +92,10 @@ python app.py
 
 ```bash
 $ curl http://localhost:8000/tacos
-404 Not Found
+"404 Not Found"
 
 $ curl http://localhost:8000/tacos/
-404 Not Found
+"Hello, tacos!"
 ```
 
 ## Recipe books

--- a/docs/guides/agnostic/recipes.md
+++ b/docs/guides/agnostic/recipes.md
@@ -50,32 +50,50 @@ This will add all the routes in the `tacos` recipe under the `/tacos` path, mean
 
 ## Which features are available on recipes?
 
-Recipes expose the following features, which can be used just as you would on the `App` object:
+**You can use all the features that are normally available to a regular `App`.** In fact, the `Recipe` class is a subclass of `App`.
 
-- [HTTP routes](../http/routing.md), e.g. `@recipe.route()`.
-- [WebSocket routes](../websockets/routing.md), .e.g `@recipe.websocket_route()`.
-- [HTTP redirects](../http/redirecting.md), e.g. `recipe.redirect(name="recipe:foo")`.
-- [Templates](./templates.md), e.g. `await recipe.template()`.
+This includes, but is not limited to:
 
-::: tip
-The `url_for()` template global is also available from recipes, and works no differently than for the `App`.
+- [Routing](../http/routing.md), e.g. `@recipe.route(...)`, `@recipe.websocket_route(...)`, `.url_for()`, etc.
+- [Error handling](../http/error-handling.md), e.g. `@recipe.error_handler()`.
+- [Redirecting](../http/redirecting.md), e.g. `recipe.redirect(...)`
+- [Middleware](../http/middleware.md), e.g. `recipe.add_middleware(...)`.
 
-This means that you must use the namespaced name if the target route has been registered on the recipe, e.g. `url_for("recipe:foo")`.
+Note, however, that [lifespan event handlers](./events.md) only get called on the root application.
 
-See [Reversing named routes](../http/routing.md#reversing-named-routes) for more information on `url_for()`.
-:::
+**Caveat: root routes on recipes**
 
-::: tip
-If your recipe needs to use its own templates, you can pass an adequate `templates_dir` to the `Recipe` constructor. Otherwise, the same `templates_dir` as the `App` will be used.
-:::
+The fact that a `Recipe` behaves just like any other `App` also means that it applies the exact same [routing algorithm](../http/routing.md#how-are-requests-processed) than the `App`.
 
-::: tip
-You can decorate your recipe views with [hooks](../http/hooks.md) as usual.
-:::
+In particular, a root route `/` registered on a recipe will be mounted on the `App` at `/{recipe.prefix}/` — note the trailing slash!
 
-::: warning CAVEAT
-Note that recipes apply the exact same [routing algorithm](../http/routing.md#how-are-requests-processed) than the `App`. In particular, the `/` route will be mounted on the `App` at `/{prefix}/`, _not_ `/{prefix}`. Accessing `/{prefix}` would return a 404 error, as per the routing algorithm.
-:::
+```python
+from bocadillo import App, Recipe
+
+tacos = Recipe("tacos")
+
+@tacos.route("/")
+async def index(req, res):
+    res.text = "Hello, tacos!"
+
+app = App()
+app.recipe(tacos)
+
+if __name__ == "__main__":
+    app.run()
+```
+
+```bash
+python app.py
+```
+
+```bash
+$ curl http://localhost:8000/tacos
+404 Not Found
+
+$ curl http://localhost:8000/tacos/
+404 Not Found
+```
 
 ## Recipe books
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,25 +4,18 @@ from typing import NamedTuple
 import pytest
 from click.testing import CliRunner
 
-from bocadillo import App, API, Templates
+from bocadillo import App, API, Templates, Recipe
 
 
-@pytest.fixture(params=[App, API])
+# Tests that use the `app` fixture will run once for each of these
+# application classes.
+APP_CLASSES = [App, API, lambda: Recipe("tacos")]
+
+
+@pytest.fixture(params=APP_CLASSES)
 def app(request):
     cls = request.param
-    _app = cls()
-    _websocket_connect = _app.client.websocket_connect
-
-    def websocket_connect(url, *args, **kwargs):
-        session = _websocket_connect(url, *args, **kwargs)
-        # Receives bytes by default
-        session.receive_json = lambda: json.loads(session.receive_text())
-        # Sends bytes by default
-        session.send_json = lambda value: session.send_text(json.dumps(value))
-        return session
-
-    _app.client.websocket_connect = websocket_connect
-    return _app
+    return cls()
 
 
 @pytest.fixture

--- a/tests/test_http_route_reverse.py
+++ b/tests/test_http_route_reverse.py
@@ -46,13 +46,15 @@ def test_name_is_inferred_from_view_name(app: App):
     assert url == "/about/Godzilla"
 
 
-def test_use_namespace(app: App):
+def test_if_route_has_namespace_then_must_be_used_when_reversing(app: App):
     @app.route("/about", namespace="blog")
     async def about(req, res):
         pass
 
-    url = app.url_for("blog:about")
-    assert url == "/about"
+    assert app.url_for("blog:about") == "/about"
+
+    with pytest.raises(HTTPError):
+        app.url_for("about")
 
 
 def test_reverse_named_sub_app_route(app: App):

--- a/tests/test_mount.py
+++ b/tests/test_mount.py
@@ -1,6 +1,4 @@
-import pytest
-
-from bocadillo import App, HTTPError
+from bocadillo import App
 
 
 def test_access_sub_route(app: App):
@@ -8,26 +6,10 @@ def test_access_sub_route(app: App):
 
     @other.route("/foo")
     async def foo(req, res):
-        pass
+        res.text = "OK"
 
     app.mount("/other", other)
 
     r = app.client.get("/other/foo")
     assert r.status_code == 200
-
-
-@pytest.mark.parametrize("with_name", (True, False))
-def test_url_for(app: App, with_name: bool):
-    other = App("other" if with_name else None)
-
-    @other.route("/foo")
-    async def foo(req, res):
-        pass
-
-    app.mount("/other", other)
-
-    if with_name:
-        assert app.url_for("other:foo") == "/other/foo"
-    else:
-        with pytest.raises(HTTPError):
-            app.url_for("other:foo")
+    assert r.text == "OK"

--- a/tests/test_mount.py
+++ b/tests/test_mount.py
@@ -1,1 +1,33 @@
-# TODO
+import pytest
+
+from bocadillo import App, HTTPError
+
+
+def test_access_sub_route(app: App):
+    other = App()
+
+    @other.route("/foo")
+    async def foo(req, res):
+        pass
+
+    app.mount("/other", other)
+
+    r = app.client.get("/other/foo")
+    assert r.status_code == 200
+
+
+@pytest.mark.parametrize("with_name", (True, False))
+def test_url_for(app: App, with_name: bool):
+    other = App("other" if with_name else None)
+
+    @other.route("/foo")
+    async def foo(req, res):
+        pass
+
+    app.mount("/other", other)
+
+    if with_name:
+        assert app.url_for("other:foo") == "/other/foo"
+    else:
+        with pytest.raises(HTTPError):
+            app.url_for("other:foo")

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -53,3 +53,28 @@ def test_use_namespace(app: App):
 
     url = app.url_for("blog:about")
     assert url == "/about"
+
+
+def test_reverse_named_sub_app_route(app: App):
+    sub = App("sub")
+
+    @sub.route("/foo")
+    async def foo(req, res):
+        pass
+
+    app.mount("/sub", sub)
+
+    assert app.url_for("sub:foo") == "/sub/foo"
+
+
+def test_cannot_reverse_unnamed_sub_app_route(app: App):
+    sub = App()
+
+    @sub.route("/foo")
+    async def foo(req, res):
+        pass
+
+    app.mount("/sub", sub)
+
+    with pytest.raises(HTTPError):
+        app.url_for("sub:foo")


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #160 

## Proposed changes

- Add a `name` parameter and attribute to `App` — allows to reverse routes of sub-apps by name (will be documented later).
- Refactor `Recipe` so that it is a subclass of `App`.
- Add basic tests for `App.mount`.