### PR TITLE
Middleware initialisation + better middleware docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules/
 .coverage
 # Private debug scripts
 ./_*.py
+# LineCount output
+out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ As a result, we strongly recommend you read this document carefully before upgra
 
 ## [Unreleased]
 
+### Added
+
+- New base class for ASGI middleware: `ASGIMiddleware`.
+  - Expects the `inner` middleware and an `app` instance when instanciated — which allows to perform initialisation by overriding `__init__()`.
+  - In the docs, old-style ASGI middleware has been rebranded as "pure" ASGI middleware.
+
+### Changed
+
+- HTTP middleware classes can now expect both the `inner` middleware _and_ the `app` instance to be passed as positional arguments, instead of only `inner`. This allows to perform initialisation on the `app` in the middleware's `__init__()` method.
+
 ## [v0.12.0] - 2019-02-22
 
 This release contains replacements for important features (`API`, app-level template rendering). Their old usage has been deprecated but is still available until the next minor release.

--- a/bocadillo/__init__.py
+++ b/bocadillo/__init__.py
@@ -1,6 +1,6 @@
 from .applications import API, App
 from .errors import HTTPError
-from .middleware import Middleware
+from .middleware import ASGIMiddleware, Middleware
 from .recipes import Recipe
 from .response import Response
 from .request import Request

--- a/bocadillo/app_types.py
+++ b/bocadillo/app_types.py
@@ -10,8 +10,17 @@ Scope = dict
 Event = MutableMapping[str, Any]
 Receive = Callable[[], Awaitable[Event]]
 Send = Callable[[Event], None]
-ASGIAppInstance = Callable[[Receive, Send], Awaitable[None]]
-ASGIApp = Callable[[Scope], ASGIAppInstance]
+
+
+class ASGIAppInstance:
+    def __call__(self, receive: Receive, send: Send) -> None:
+        raise NotImplementedError
+
+
+class ASGIApp:
+    def __call__(self, scope: Scope) -> ASGIAppInstance:
+        raise NotImplementedError
+
 
 # HTTP
 AsyncHandler = Callable[[Request, Response, Any], Awaitable[None]]

--- a/bocadillo/applications.py
+++ b/bocadillo/applications.py
@@ -40,6 +40,7 @@ from .error_handlers import error_to_text
 from .errors import HTTPError, HTTPErrorMiddleware, ServerErrorMiddleware
 from .media import UnsupportedMediaType, get_default_handlers
 from .meta import DocsMeta
+from .middleware import ASGIMiddleware
 from .request import Request
 from .response import Response
 from .routing import RoutingMixin
@@ -318,6 +319,8 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
         - [ASGI middleware](../guides/agnostic/asgi-middleware.md)
         - [ASGI](https://asgi.readthedocs.io)
         """
+        if issubclass(middleware_cls, ASGIMiddleware):
+            args = (self, *args)
         self.asgi = middleware_cls(self.asgi, *args, **kwargs)
 
     def on(self, event: str, handler: Optional[EventHandler] = None):

--- a/bocadillo/applications.py
+++ b/bocadillo/applications.py
@@ -364,9 +364,9 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
             media_type=self.media_type,
             media_handler=self.media_handlers[self.media_type],
         )
-        response = await self.server_error_middleware(req, res)
+        res: Response = await self.server_error_middleware(req, res)
 
-        await response(receive, send)
+        await res(receive, send)
 
         # Re-raise the exception to allow the server to log the error
         # and for the test client to optionally re-raise it too.

--- a/bocadillo/applications.py
+++ b/bocadillo/applications.py
@@ -293,7 +293,7 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
 
         return wrapper
 
-    def add_middleware(self, middleware_cls, **kwargs):
+    def add_middleware(self, middleware_cls, *args, **kwargs):
         """Register a middleware class.
 
         # Parameters
@@ -305,10 +305,10 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
         - [Middleware](../guides/http/middleware.md)
         """
         self.exception_middleware.app = middleware_cls(
-            self.exception_middleware.app, **kwargs
+            self.exception_middleware.app, self, **kwargs
         )
 
-    def add_asgi_middleware(self, middleware_cls, *args, **kwargs):
+    def add_asgi_middleware(self, middleware_cls, **kwargs):
         """Register an ASGI middleware class.
 
         # Parameters
@@ -319,8 +319,7 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
         - [ASGI middleware](../guides/agnostic/asgi-middleware.md)
         - [ASGI](https://asgi.readthedocs.io)
         """
-        if issubclass(middleware_cls, ASGIMiddleware):
-            args = (self, *args)
+        args = (self,) if issubclass(middleware_cls, ASGIMiddleware) else ()
         self.asgi = middleware_cls(self.asgi, *args, **kwargs)
 
     def on(self, event: str, handler: Optional[EventHandler] = None):

--- a/bocadillo/applications.py
+++ b/bocadillo/applications.py
@@ -305,7 +305,7 @@ class App(TemplatesMixin, RoutingMixin, metaclass=DocsMeta):
         - [Middleware](../guides/http/middleware.md)
         """
         self.exception_middleware.app = middleware_cls(
-            self.exception_middleware.app, self, **kwargs
+            self.exception_middleware.app, app=self, **kwargs
         )
 
     def add_asgi_middleware(self, middleware_cls, **kwargs):

--- a/bocadillo/errors.py
+++ b/bocadillo/errors.py
@@ -106,7 +106,7 @@ class ServerErrorMiddleware(HTTPApp):
         if self.exception is not None:
             raise self.exception from None
 
-    async def __call__(self, req: Request, res: Response):
+    async def __call__(self, req: Request, res: Response) -> Response:
         try:
             res = await self.app(req, res)
         except BaseException as exc:

--- a/bocadillo/middleware.py
+++ b/bocadillo/middleware.py
@@ -13,14 +13,14 @@ class Middleware(HTTPApp):
     """Base class for middleware classes.
 
     # Parameters
-    parent (callable): the parent middleware.
+    inner (callable): the inner middleware that this middleware wraps.
     app (App): the application instance.
     kwargs (any):
         Keyword arguments passed when registering the middleware on `app`.
     """
 
-    def __init__(self, parent: HTTPApp, app: "App", **kwargs):
-        self.parent = parent
+    def __init__(self, inner: HTTPApp, app: "App", **kwargs):
+        self.inner = inner
         self.app = app
         self.kwargs = kwargs
 
@@ -78,7 +78,7 @@ class Middleware(HTTPApp):
         if before_res:
             return before_res
 
-        res = await self.parent(req, res)
+        res = await self.inner(req, res)
 
         res = (
             await call_async(self.after_dispatch, req, res)  # type: ignore
@@ -94,16 +94,16 @@ class ASGIMiddleware(ASGIApp):
     """Base class for ASGI middleware classes.
 
     # Parameters
-    parent (callable): the parent middleware.
+    inner (callable): the inner middleware.
     app (App): the application instance.
     kwargs (any):
         Keyword arguments passed when registering the middleware on `app`.
     """
 
-    def __init__(self, parent: ASGIApp, app: "App" = None, **kwargs):
-        self.parent = parent
+    def __init__(self, inner: ASGIApp, app: "App", **kwargs):
+        self.inner = inner
         self.app = app
         self.kwargs = kwargs
 
     def __call__(self, scope: Scope) -> ASGIAppInstance:
-        return self.parent(scope)
+        return self.inner(scope)

--- a/bocadillo/middleware.py
+++ b/bocadillo/middleware.py
@@ -19,7 +19,8 @@ class Middleware(HTTPApp):
         Keyword arguments passed when registering the middleware on `app`.
     """
 
-    def __init__(self, inner: HTTPApp, app: "App", **kwargs):
+    def __init__(self, inner: HTTPApp, app: "App" = None, **kwargs):
+        # NOTE: app defaults to `None` to support old-style HTTP middleware.
         self.inner = inner
         self.app = app
         self.kwargs = kwargs

--- a/bocadillo/middleware.py
+++ b/bocadillo/middleware.py
@@ -1,9 +1,12 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from .app_types import HTTPApp
+from .app_types import ASGIApp, ASGIAppInstance, HTTPApp, Scope
 from .compat import call_async
 from .request import Request
 from .response import Response
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .applications import App
 
 
 class Middleware(HTTPApp):
@@ -84,3 +87,12 @@ class Middleware(HTTPApp):
         return res
 
     __call__ = process
+
+
+class ASGIMiddleware(ASGIApp):
+    def __init__(self, parent: ASGIApp, app: "App" = None, **kwargs):
+        self.parent = parent
+        self.app = app
+
+    def __call__(self, scope: Scope) -> ASGIAppInstance:
+        return self.parent(scope)

--- a/docs/guides/agnostic/asgi-middleware.md
+++ b/docs/guides/agnostic/asgi-middleware.md
@@ -11,7 +11,7 @@ Similarities:
 
 Differences:
 
-- ASGI middleware is **generic** works both in the context of HTTP _and_ WebSocket.
+- ASGI middleware is **generic**; it works both in the context of HTTP _and_ WebSocket.
 - ASGI middleware classes implement the [ASGI] interface directly, which means you can use any third-party ASGI middleware class without extra plumbing.
 - ASGI middleware operates before any HTTP middleware.
 
@@ -26,6 +26,10 @@ from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 
 app.add_asgi_middleware(HTTPSRedirectMiddleware)
 ```
+
+::: tip
+Extra keyword arguments passed to `.add_asgi_middleware()` are forwareded to the middleware class when it is instanciated.
+:::
 
 ## Built-in ASGI middleware
 

--- a/docs/guides/agnostic/asgi-middleware.md
+++ b/docs/guides/agnostic/asgi-middleware.md
@@ -6,14 +6,14 @@ ASGI middleware provides global behavior at the earliest stage in the processing
 
 Similarities:
 
-- The same [stack-style processing algorithm](../http/middleware.md#how-http-middleware-is-applied) is used.
+- The same [stack-like processing algorithm](../http/middleware.md#how-http-middleware-is-applied) is used.
 - ASGI middleware takes the form of middleware classes, too.
 
 Differences:
 
 - ASGI middleware is **generic**; it works both in the context of HTTP _and_ WebSocket.
 - ASGI middleware classes implement the [ASGI] interface directly, which means you can use any third-party ASGI middleware class without extra plumbing.
-- ASGI middleware operates before any HTTP middleware.
+- ASGI middleware operates before any HTTP middleware (higher priority).
 
 ## Using ASGI middleware
 
@@ -28,7 +28,7 @@ app.add_asgi_middleware(HTTPSRedirectMiddleware)
 ```
 
 ::: tip
-Extra keyword arguments passed to `.add_asgi_middleware()` are forwareded to the middleware class when it is instanciated.
+Extra keyword arguments passed to `.add_asgi_middleware()` are forwarded to the middleware class when it is instanciated.
 :::
 
 ## Built-in ASGI middleware

--- a/docs/how-to/middleware.md
+++ b/docs/how-to/middleware.md
@@ -6,24 +6,25 @@ They come in 2 flavors: [HTTP middleware](../guides/http/middleware.md) and [ASG
 
 ## HTTP middleware
 
+The HTTP middleware framework provides two hooks:
+
+- `.before_dispatch()`: called before an HTTP request is dispatched (i.e. processed by the child middleware).
+- `.after_dispatch()`: called after it has been dispatched.
+
+Each hook is given the current `Request` and `Response` objects, and can alter them as necessary to achieve the desired behavior.
+
 ### Basic usage
 
-The HTTP middleware framework provides two hooks, namely `before_dispatch()` and `after_dispatch()`, which are called respectively before and after an HTTP request is dispatched and an HTTP response is obtained.
-
-Each hook is given the current `Request` and `Response` objects
-(the same that will be passed down to the views) and can alter them as is
-required to achieve the desired behavior.
-
-A bare-bones middleware looks like this:
+HTTP middleware can be created by subclassing from [`Middleware`][http middleware]. A bare-bones HTTP middleware looks like this:
 
 ```python
 from bocadillo import Middleware, Request, Response
 
-class TransparentMiddleware(Middleware):
+class NoOpMiddleware(Middleware):
 
     async def before_dispatch(self, req: Request, res: Response):
         pass
-       
+
     async def after_dispatch(self, req: Request, res: Response):
         pass
 ```
@@ -34,48 +35,48 @@ The `.before_dispatch()` and `.after_dispatch()` can also be plain, non-`async` 
 
 ### Interrupting request processing
 
-If the `before_dispatch` hook returns the `Response` object, no further
+If the `.before_dispatch()` hook returns the `Response` object, no further
 processing is performed.
 
-For example, this middleware will result in a `202 Accepted: Foo` response being
-returned for *any* request made to the application.
+For example, this middleware will result in a `202 Accepted` response being
+returned for _any_ request made to the application.
 
 ```python{8}
 from bocadillo import Middleware, Request, Response
 
-class FooMiddleware(Middleware):
+class Always202Middleware(Middleware):
 
     async def before_dispatch(self, req: Request, res: Response):
-        res.text = "Foo"
         res.status_code = 202
         return res
 ```
 
 Note: returning a response in `after_dispatch` has no effect.
 
-### Configuration
+### Configuration and initialisation
 
-Keyword arguments passed to `app.add_middleware()` as passed down to the
-middleware's `__init__()` method. This means that you can grab them there to
-perform extra initialisation logic.
+Middleware configuaration and initialisation can be performed by overriding its `__init__()` method, which is given the following:
 
-```python
-from bocadillo import Middleware
+- `parent`: this is the parent middleware.
+- `app`: this is the application instance which this middleware is being registered on.
+- `**kwargs`: any keyword arguments passed to `app.add_middleware()`.
 
-class MaybeMiddleware(Middleware):
-    
-    def __init__(self, *args, flag=False, **kwargs):
-        super().__init__(*args, **kwargs)
-        if flag:
-            # Do stuff if flag is True
-            pass
-```
-
-Users will be able to register the middleware using `app.add_middleware()`:
+For example, here's a middleware that registers a startup [event handler](../guides/agnostic/events.md) if a flag argument was passed:
 
 ```python
-app = App()
-app.add_middleware(MaybeMiddleware, flag=True)
+from bocadillo import App, Middleware
+
+class ExpensiveMiddleware(Middleware):
+
+    def __init__(self, parent, app: App, warmup=False, **kwargs):
+        super().__init__(parent, app, **kwargs)
+
+        if not warmup:
+            return
+
+        @app.on("startup")
+        async def perform_warmup():
+            print("Warming up middleware…")
 ```
 
 ### Middleware from scratch
@@ -83,53 +84,90 @@ app.add_middleware(MaybeMiddleware, flag=True)
 As it turns out, the `before_dispatch()` and `after_dispatch()` hooks on
 `Middleware` are just helpers.
 
-If they don't fit your needs, you can also implement the `__call__()` method directly.
+If they don't fit your needs, you can also implement the asynchronous `.__call__()` method directly. Subclassing from `Middleware` will ensure that the parent, app and kwargs are available for use.
 
-Subclassing from `Middleware` will ensure that you are still given the
-underlying HTTP `app` and keyword arguments passed upon registering the
-middleware. 
+For example, here's a "no-op" middleware that forwards request processing to its parent:
 
 ```python
 from bocadillo import Request, Response, Middleware
 
-class TransparentMiddleware(Middleware):
+class NoOpMiddleware(Middleware):
 
-    def __call__(self, req: Request, res: Response) -> Response:
-        return await self.app(req, res)
+    async def __call__(self, req: Request, res: Response) -> Response:
+        return await self.parent(req, res)
 ```
 
 ## ASGI middleware
 
-In order to support lower-level middleware needs, you can also write a
-middleware class that implements the [ASGI] interface directly.
+If you need global behavior that don't belong to the world of HTTP, ASGI middleware is for you. They are lower-level middleware classes that implement the [ASGI] interface directly.
+
+### Using the `ASGIMiddleware` base class
+
+Similar to `Middleware`, Bocadillo provides an [`ASGIMiddleware`][asgi middleware] base class targeted at writing ASGI middleware.
+
+Here's an example middleware that implements integration with an imaginary database library:
 
 ```python
-class SpecialPathMiddleware:
+from bocadillo import App, ASGIMiddleware
+from db import Database
 
-    def __init__(self, app, special_path: str = "special"):
-        self.app = app
-        self.path = special_path
-    
-    def special(self, scope: dict):
-        async def asgi(receive, send):
-            # TODO: do something special
-            pass
-        return asgi
+class DatabaseMiddleware(ASGIMiddleware):
+    def __init__(self, parent, app: App, url: str):
+        super().__init__(parent, app)
+        self.db = Database(url)
+        app.on("startup", self.db.connect)
+        app.on("shutdown", self.db.disconnect)
 
+    # ASGI implementation
     def __call__(self, scope: dict):
-        if scope["path"] == self.path:
-            return self.special(scope)
-        return self.app(scope)
+        # Make the db available to the request scope.
+        scope["db"] = self.db
+        return super().__call__(scope)
 ```
 
-::: warning
+### Pure ASGI middleware
+
+Bocadillo also supports "pure" ASGI middleware, i.e. middleware that only expects their `parent` middleware to be given to their constructor.
+
+::: tip NOTE
+Third-party ASGI middleware classes are typically given in this form.
+:::
+
+Note that, because it performs initialisation on the application instance, the previous `DatabaseMiddleware` cannot be rewritten as a pure ASGI middleware.
+
+As an example, here's a pure ASGI middleware that injects a static value in the request scope:
+
+```python
+from bocadillo import App
+
+class Inject:
+    def __init__(self, parent, value: str):
+        self.parent = parent
+        self.value = value
+
+    # ASGI implementation
+    def __call__(self, scope: dict):
+        scope["x-value"] = self.value
+        return self.parent(scope)
+```
+
+Example usage:
+
+```python
+app = App()
+app.add_asgi_middleware(Inject, value="foo")
+
+@app.route("/")
+async def index(req, res):
+    res.text = req["x-value"]  # "foo"
+```
+
+### Caveats
+
 Bocadillo is not able to perform error handling at the ASGI middleware level.
 You must make sure you implement the ASGI protocol correctly and send
 the correct ASGI events if something goes wrong.
-:::
 
-While ASGI middleware is very low-level, it also means that
-third-party middleware classes implemented in this form can be plugged in without
-extra plumbing. 
-
-[ASGI]: https://asgi.readthedocs.io
+[asgi]: https://asgi.readthedocs.io
+[http middleware]: ../api/middleware.md#middleware
+[asgi middleware]: ../api/middleware.md#asgimiddleware

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -23,6 +23,7 @@ generate:
   - middleware.md:
       - bocadillo.middleware:
           - bocadillo.middleware.Middleware+
+          - bocadillo.middleware.ASGIMiddleware+
   - recipes.md:
       - bocadillo.recipes:
           - bocadillo.recipes.RecipeBase+

--- a/tests/test_asgi_middleware.py
+++ b/tests/test_asgi_middleware.py
@@ -1,34 +1,6 @@
 from bocadillo import App, ASGIMiddleware
 
 
-def test_raw_asgi_middleware():
-    initialized = False
-    called = False
-
-    class Middleware:
-        def __init__(self, app):
-            nonlocal initialized
-            self.app = app
-            initialized = True
-
-        def __call__(self, scope: dict):
-            nonlocal called
-            called = True
-            return self.app(scope)
-
-    app = App()
-    app.add_asgi_middleware(Middleware)
-
-    assert initialized
-
-    @app.route("/")
-    async def index(req, res):
-        pass
-
-    app.client.get("/")
-    assert called
-
-
 def test_asgi_middleware():
     app = App()
     params = None
@@ -44,3 +16,31 @@ def test_asgi_middleware():
     app.add_asgi_middleware(Middleware, hello="world")
     assert received_app
     assert params == {"hello": "world"}
+
+
+def test_pure_asgi_middleware():
+    initialized = False
+    called = False
+
+    class Middleware:
+        def __init__(self, inner):
+            nonlocal initialized
+            self.inner = inner
+            initialized = True
+
+        def __call__(self, scope: dict):
+            nonlocal called
+            called = True
+            return self.inner(scope)
+
+    app = App()
+    app.add_asgi_middleware(Middleware)
+
+    assert initialized
+
+    @app.route("/")
+    async def index(req, res):
+        pass
+
+    app.client.get("/")
+    assert called

--- a/tests/test_asgi_middleware.py
+++ b/tests/test_asgi_middleware.py
@@ -35,8 +35,8 @@ def test_asgi_middleware():
     received_app = False
 
     class Middleware(ASGIMiddleware):
-        def __init__(self, parent, app: App, **kwargs):
-            super().__init__(parent, app)
+        def __init__(self, inner, app: App, **kwargs):
+            super().__init__(inner, app)
             nonlocal params, received_app
             params = kwargs
             received_app = isinstance(app, App)

--- a/tests/test_asgi_middleware.py
+++ b/tests/test_asgi_middleware.py
@@ -1,16 +1,46 @@
-from starlette.middleware.gzip import GZipMiddleware
-
-from bocadillo import App
+from bocadillo import App, ASGIMiddleware
 
 
-def test_if_asgi_middleware_is_applied():
-    app = App(enable_gzip=False)
-    app.add_asgi_middleware(GZipMiddleware, minimum_size=0)
+def test_raw_asgi_middleware():
+    initialized = False
+    called = False
+
+    class Middleware:
+        def __init__(self, app):
+            nonlocal initialized
+            self.app = app
+            initialized = True
+
+        def __call__(self, scope: dict):
+            nonlocal called
+            called = True
+            return self.app(scope)
+
+    app = App()
+    app.add_asgi_middleware(Middleware)
+
+    assert initialized
 
     @app.route("/")
     async def index(req, res):
         pass
 
-    response = app.client.get("/", headers={"Accept-Encoding": "gzip"})
-    assert response.status_code == 200
-    assert response.headers["content-encoding"] == "gzip"
+    app.client.get("/")
+    assert called
+
+
+def test_asgi_middleware():
+    app = App()
+    params = None
+    received_app = False
+
+    class Middleware(ASGIMiddleware):
+        def __init__(self, parent, app: App, **kwargs):
+            super().__init__(parent, app)
+            nonlocal params, received_app
+            params = kwargs
+            received_app = isinstance(app, App)
+
+    app.add_asgi_middleware(Middleware, hello="world")
+    assert received_app
+    assert params == {"hello": "world"}

--- a/tests/test_http_middleware.py
+++ b/tests/test_http_middleware.py
@@ -7,16 +7,27 @@ from bocadillo import App, Middleware, HTTPError
 
 
 @contextmanager
-def build_middleware(expect_kwargs=None, sync=False, expect_call_after=True):
+def build_middleware(
+    expect_kwargs=None, sync=False, expect_call_after=True, old_style=False
+):
     called = {"before": False, "after": False}
     kwargs = None
 
     class SetCalled(Middleware):
-        def __init__(self, inner, app: App, **kw):
-            super().__init__(inner, app, **kw)
-            nonlocal kwargs
-            kwargs = kw
-            assert isinstance(app, App)
+        if old_style:
+
+            def __init__(self, inner, app: App, **kw):
+                super().__init__(inner, app, **kw)
+                nonlocal kwargs
+                kwargs = kw
+                assert isinstance(app, App)
+
+        else:
+
+            def __init__(self, inner, **kw):
+                super().__init__(inner, **kw)
+                nonlocal kwargs
+                kwargs = kw
 
         if sync:
 
@@ -44,12 +55,25 @@ def build_middleware(expect_kwargs=None, sync=False, expect_call_after=True):
 
     assert called["before"] is True
     assert called["after"] is expect_call_after
+
     if expect_kwargs is not None:
+        kwargs.pop("app", None)  # old-style compatibility
         assert kwargs == expect_kwargs
 
 
 def test_if_middleware_is_added_then_it_is_called(app: App):
     with build_middleware() as middleware:
+        app.add_middleware(middleware)
+
+        @app.route("/")
+        async def index(req, res):
+            pass
+
+        app.client.get("/")
+
+
+def test_old_style_middleware(app: App):
+    with build_middleware(old_style=True) as middleware:
         app.add_middleware(middleware)
 
         @app.route("/")

--- a/tests/test_http_middleware.py
+++ b/tests/test_http_middleware.py
@@ -12,10 +12,11 @@ def build_middleware(expect_kwargs=None, sync=False, expect_call_after=True):
     kwargs = None
 
     class SetCalled(Middleware):
-        def __init__(self, app, **kw):
+        def __init__(self, parent, app: App, **kw):
+            super().__init__(parent, app, **kw)
             nonlocal kwargs
             kwargs = kw
-            super().__init__(app, **kw)
+            assert isinstance(app, App)
 
         if sync:
 
@@ -118,8 +119,7 @@ def test_errors_raised_in_callback_are_handled(app: App, when):
     async def index(req, res):
         pass
 
-    client = app.build_client(raise_server_exceptions=False)
-    r = client.get("/")
+    r = app.client.get("/")
     assert r.status_code == 200
     assert r.text == "gotcha!"
 

--- a/tests/test_http_middleware.py
+++ b/tests/test_http_middleware.py
@@ -12,8 +12,8 @@ def build_middleware(expect_kwargs=None, sync=False, expect_call_after=True):
     kwargs = None
 
     class SetCalled(Middleware):
-        def __init__(self, parent, app: App, **kw):
-            super().__init__(parent, app, **kw)
+        def __init__(self, inner, app: App, **kw):
+            super().__init__(inner, app, **kw)
             nonlocal kwargs
             kwargs = kw
             assert isinstance(app, App)


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #171 

## Proposed changes

- add support for `Middleware` that accept `inner, app, **kwargs` instead of `inner, **kwargs` only.
- Create a base `ASGIMiddleware` that also expects `inner` and `app`.
- Lots of docs improvements.

These changes allow to perform app initialisation in middleware classes.
