### PR TITLE
Fix missing WebSocket attributes

### DIFF
--- a/bocadillo/websockets.py
+++ b/bocadillo/websockets.py
@@ -76,6 +76,15 @@ class WebSocket:
         """
         return self._ws.url
 
+    @property
+    def headers(self):
+        """Headers attached to the connection request.
+        
+        # See Also
+        - [starlette.WebSocket.header]s(https://www.starlette.io/websockets/#headers)
+        """
+        return self._ws.headers
+
     # Connection handling.
 
     async def accept(self, subprotocol: str = None) -> None:

--- a/bocadillo/websockets.py
+++ b/bocadillo/websockets.py
@@ -1,19 +1,22 @@
-from typing import Awaitable, Callable, Optional, Any, Union, Tuple
+from typing import Any, Awaitable, Callable, Optional, Tuple, Union
 
-from starlette.datastructures import URL
-from starlette.websockets import (
-    WebSocket as StarletteWebSocket,
-    WebSocketDisconnect as _WebSocketDisconnect,
-)
+from starlette.datastructures import URL, Headers, QueryParams
+from starlette.websockets import WebSocket as StarletteWebSocket
+from starlette.websockets import WebSocketDisconnect as _WebSocketDisconnect
 
-from .app_types import Event, Scope, Receive, Send
+from .app_types import Event, Receive, Scope, Send
 from .constants import WEBSOCKET_CLOSE_CODES
 
 
 class WebSocket:
     """Represents a WebSocket connection.
 
+    See also [WebSockets](/guides/websockets/).
+
     # Parameters
+    scope (dict): ASGI scope.
+    receive (callable): ASGI receive function.
+    send (callable): ASGI send function.
     value_type (str):
         The type of messages received or sent over the WebSocket.
         If given, overrides `receive_type` and `send_type`.
@@ -27,13 +30,19 @@ class WebSocket:
     caught_close_codes (tuple of int):
         Close codes of `WebSocketDisconnect` exceptions that should be
         caught and silenced. Defaults to `(1000, 1001)`.
-    args (any):
-        Passed to the underlying Starlette `WebSocket` object. This is
-        typically the ASGI `scope`, `receive` and `send` objects.
+
+    # Attributes
+    url (str-like): the URL which the WebSocket connection was made to.
+    headers (dict): headers attached to the connection request.
+    query_params (dict): parsed query parameters.
     """
 
     __default_receive_type__ = "text"
     __default_send_type__ = "text"
+
+    url: URL
+    headers: Headers
+    query_params: QueryParams
 
     def __init__(
         self,
@@ -67,23 +76,11 @@ class WebSocket:
         self.receive_type = receive_type
         self.send_type = send_type
 
-    @property
-    def url(self) -> URL:
-        """The URL which the WebSocket connection was made to.
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._ws, name)
 
-        # See Also
-        - [starlette.WebSocket.url](https://www.starlette.io/websockets/#url)
-        """
-        return self._ws.url
-
-    @property
-    def headers(self):
-        """Headers attached to the connection request.
-        
-        # See Also
-        - [starlette.WebSocket.header]s(https://www.starlette.io/websockets/#headers)
-        """
-        return self._ws.headers
+    def __getitem__(self, name: str) -> Any:
+        return self._ws.__getitem__(name)
 
     # Connection handling.
 

--- a/docs/guides/websockets/routing.md
+++ b/docs/guides/websockets/routing.md
@@ -62,9 +62,9 @@ dictionary-like object.
 Example if a client requests `ws://localhost:8000/chatroom?add=1&sub=2&sub=3`:
 
 ```python
-req.query_params["add"]  # "1"
-req.query_params["sub"]  # "2"  (first item)
-req.query_params.getlist("sub")  # ["2", "3"]
+ws.query_params["add"]  # "1"
+ws.query_params["sub"]  # "2"  (first item)
+ws.query_params.getlist("sub")  # ["2", "3"]
 ```
 
 [deployment]: ../../discussions/deployment.md

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -103,6 +103,18 @@ def test_websocket_url(app: App):
         pass
 
 
+def test_websocket_headers(app: App):
+    @app.websocket_route("/test")
+    async def test(ws: WebSocket):
+        async with ws:
+            await ws.send_json(dict(ws.headers))
+
+    with app.client.websocket_connect("/test", headers={"X-Foo": "bar"}) as ws:
+        headers = ws.receive_json()
+
+    assert headers["x-foo"] == "bar"
+
+
 # Encoding / decoding of messages
 
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -115,6 +115,19 @@ def test_websocket_headers(app: App):
     assert headers["x-foo"] == "bar"
 
 
+def test_websocket_query_params(app: App):
+    @app.websocket_route("/test")
+    async def test(ws: WebSocket):
+        async with ws:
+            print(ws["query_string"])
+            await ws.send_json(dict(ws.query_params))
+
+    with app.client.websocket_connect("/test?q=hello") as ws:
+        query_params = ws.receive_json()
+
+    assert query_params["q"] == "hello"
+
+
 # Encoding / decoding of messages
 
 


### PR DESCRIPTION
<!--
A PR should always link to an issue.
If there's none yet, please open one so we can discuss the problem first.
-->
Fixes #200 

## Proposed changes

- `WebSocket` now delegates attribute access to the underlying Starlette WebSocket object.
- Consequence: `query_params` and `headers` are now properly exposed.
