### PR TITLE
Fix dependency conflict for issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ INSTALL_REQUIRES = [
     "whitenoise",
     "requests",
     "python-multipart",
-    "websockets>=6.0",
     "aiodine>=1.2.5, <2.0",
 ]
 


### PR DESCRIPTION
#325

<!--
A PR should link to an issue.
If there's none yet (and the change is not trivial) please open one so we can discuss the problem first.
-->
Fixes #
Drop the dependency websockets.
Use whichever version uvicorn installs.
<!--
Update CHANGELOG.md with a description of the changes,
or add the following section:

## Proposed changes
-->
